### PR TITLE
parser: surface OAS 3.1 webhooks and components.pathItems

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ for op in openapi.operations(doc) {
   println("${op.method} ${op.path} -> ${op.operation_id}")
 }
 
+// Walk OAS 3.1 webhooks (inbound payloads)
+for wop in openapi.webhook_operations(doc) {
+  println("webhook ${wop.name} (${wop.method}) -> ${wop.operation_id}")
+}
+
+// Passthrough accessor for the 3.1-new components.pathItems map
+let shared_path_items = openapi.component_path_items(doc)
+
 // Generate Harn SDK source from the parsed document
 let src = openapi.codegen_module(doc, {
   module_name: "notion",
@@ -45,6 +53,31 @@ let src = openapi.codegen_module(doc, {
 })
 write_file("./src/lib.harn", src)
 ```
+
+### Exported surface
+
+- `parse(json_string) -> dict` — normalize a 3.1.x doc to
+  `{ openapi, info, servers, paths, webhooks, components,
+  security_schemes, tags }`. `paths` may be empty (3.1 allows
+  webhooks-only docs). `components.pathItems` is always present as a
+  dict, even when the source doc omits it.
+- `operations(doc) -> list` — flatten `doc.paths` into operation
+  records `{ method, path, operation_id, summary, parameters,
+  request_body, responses, security, tags, ... }`.
+- `webhook_operations(doc) -> list` — flatten `doc.webhooks` into
+  records `{ name, method, path_item, operation, operation_id,
+  summary, parameters, request_body, responses, security, tags }`.
+  `name` is the webhook key (e.g. `commentCreated`); downstream
+  connectors use these to know which inbound payloads to handle.
+- `component_path_items(doc) -> dict<string, PathItem>` —
+  passthrough accessor for `doc.components.pathItems` (new in
+  OAS 3.1). Returns `{}` when absent.
+- `schema(doc, ref_or_inline) -> dict` — resolve a local `$ref`, or
+  return inline schemas unchanged. Merges one level of `allOf`.
+- `enum_values(schema) -> list | nil` — extract the enum variant list,
+  or `nil` when the schema is not an enum.
+- `codegen_module(doc, options) -> string` — emit a typed Harn SDK
+  module source string.
 
 ## Development
 

--- a/src/lib.harn
+++ b/src/lib.harn
@@ -4,13 +4,26 @@
 //
 //   parse(json_string)           -> dict
 //       Parse an OpenAPI 3.1 JSON document into a normalized dict with
-//       shape { openapi, info, servers, paths, components,
-//       security_schemes, tags }. Throws on non-3.1.x docs.
+//       shape { openapi, info, servers, paths, webhooks, components,
+//       security_schemes, tags }. OAS 3.1 makes `paths` optional and
+//       introduces first-class `webhooks` plus `components.pathItems`
+//       — all three are surfaced here. Throws on non-3.1.x docs.
 //
 //   operations(doc)              -> list<operation>
-//       Flatten path-itemed operations into a list of
+//       Flatten path-itemed operations in `doc.paths` into a list of
 //       { method, path, operation_id, summary, parameters,
 //       request_body, responses, security } dicts.
+//
+//   webhook_operations(doc)      -> list<webhook_operation>
+//       Flatten OAS 3.1 `doc.webhooks` into a list of
+//       { name, method, path_item, operation } dicts. `name` is the
+//       webhook key (e.g. "commentCreated"); `method` is the HTTP
+//       verb declared on the path item; `operation` is the Operation
+//       object. Analogous to `operations()` for inbound payloads.
+//
+//   component_path_items(doc)    -> dict<string, PathItem>
+//       Passthrough accessor for `doc.components.pathItems` (new in
+//       OAS 3.1). Returns `{}` when absent.
 //
 //   schema(doc, ref_or_inline)   -> dict
 //       Resolve a `$ref` like "#/components/schemas/Foo" against the
@@ -43,12 +56,14 @@ pub fn parse(json_string: string) -> dict {
     throw "harn-openapi.parse: expected openapi 3.1.x, got " + to_string(version)
   }
   let components = raw.get("components") ?? {}
+  let components_with_path_items = {...components, pathItems: components.get("pathItems") ?? {}}
   return {
     openapi: version,
     info: raw.get("info") ?? {},
     servers: raw.get("servers") ?? [],
     paths: raw.get("paths") ?? {},
-    components: components,
+    webhooks: raw.get("webhooks") ?? {},
+    components: components_with_path_items,
     security_schemes: components.get("securitySchemes") ?? {},
     tags: raw.get("tags") ?? [],
   }
@@ -62,29 +77,64 @@ let _HTTP_METHODS = ["get", "put", "post", "delete", "options", "head", "patch",
 
 /** Flatten every operation in the doc's `paths` dict. */
 pub fn operations(doc: dict) -> list {
+  return _flatten_path_item_map(doc.get("paths") ?? {}, doc, "path")
+}
+
+/** Flatten every operation in the doc's `webhooks` dict (OAS 3.1). */
+pub fn webhook_operations(doc: dict) -> list {
+  return _flatten_path_item_map(doc.get("webhooks") ?? {}, doc, "webhook")
+}
+
+/** Passthrough accessor for `components.pathItems` (OAS 3.1). */
+pub fn component_path_items(doc: dict) -> dict {
+  let components = doc.get("components") ?? {}
+  return components.get("pathItems") ?? {}
+}
+
+fn _flatten_path_item_map(items, doc, mode) {
   var out = []
-  for entry in doc.paths {
-    let path = entry.key
+  for entry in items {
+    let key = entry.key
     let item = entry.value
     for method in _HTTP_METHODS {
       let op = item.get(method)
       if op != nil {
         let raw_params = _merge_parameters(item.get("parameters") ?? [], op.get("parameters") ?? [], doc)
-        out = out
-          + [
-          {
-          method: method,
-          path: path,
-          operation_id: op.get("operationId") ?? _synth_operation_id(method, path),
-          summary: op.get("summary") ?? "",
-          description: op.get("description") ?? "",
-          parameters: raw_params,
-          request_body: op.get("requestBody"),
-          responses: op.get("responses") ?? {},
-          security: op.get("security") ?? doc.get("security") ?? [],
-          tags: op.get("tags") ?? [],
-        },
-        ]
+        if mode == "webhook" {
+          out = out
+            + [
+            {
+            name: key,
+            method: method,
+            path_item: item,
+            operation: op,
+            operation_id: op.get("operationId") ?? _synth_operation_id(method, key),
+            summary: op.get("summary") ?? "",
+            description: op.get("description") ?? "",
+            parameters: raw_params,
+            request_body: op.get("requestBody"),
+            responses: op.get("responses") ?? {},
+            security: op.get("security") ?? doc.get("security") ?? [],
+            tags: op.get("tags") ?? [],
+          },
+          ]
+        } else {
+          out = out
+            + [
+            {
+            method: method,
+            path: key,
+            operation_id: op.get("operationId") ?? _synth_operation_id(method, key),
+            summary: op.get("summary") ?? "",
+            description: op.get("description") ?? "",
+            parameters: raw_params,
+            request_body: op.get("requestBody"),
+            responses: op.get("responses") ?? {},
+            security: op.get("security") ?? doc.get("security") ?? [],
+            tags: op.get("tags") ?? [],
+          },
+          ]
+        }
       }
     }
   }

--- a/tests/webhook_smoke.harn
+++ b/tests/webhook_smoke.harn
@@ -1,0 +1,64 @@
+// webhook_smoke — OAS 3.1 acceptance: parse() surfaces `webhooks` and
+// `components.pathItems`; `webhook_operations(doc)` flattens webhook
+// path items; a handler's request-body schema resolves via schema().
+//
+// Tracks burin-labs/harn-openapi#2.
+import { component_path_items, parse, schema, webhook_operations } from "../src/lib"
+
+pipeline default() {
+  let raw = read_file("/Users/ksinder/projects/harn-openapi/tests/fixtures/notion.openapi.json")
+  let doc = parse(raw)
+  // parse() must surface the webhooks map.
+  assert(type_of(doc.webhooks) == "dict", "doc.webhooks must be a dict")
+  let webhook_count = len(doc.webhooks)
+  println("webhooks (raw): ${webhook_count}")
+  assert(webhook_count >= 10, "expected >=10 webhooks in the Notion fixture, got ${webhook_count}")
+  // parse() must surface components.pathItems as a dict, even if empty.
+  assert(type_of(doc.components.pathItems) == "dict", "doc.components.pathItems must be a dict")
+  // component_path_items(doc) is the passthrough accessor.
+  let comp_path_items = component_path_items(doc)
+  assert(type_of(comp_path_items) == "dict", "component_path_items(doc) must return a dict")
+  println("components.pathItems: ${len(comp_path_items)}")
+  // webhook_operations(doc) flattens webhook path items into a list.
+  let webhook_ops = webhook_operations(doc)
+  println("webhook operations: ${len(webhook_ops)}")
+  assert(len(webhook_ops) >= 10, "expected >=10 webhook operations, got ${len(webhook_ops)}")
+  // Every entry must have the shape { name, method, path_item, operation, ... }.
+  for wop in webhook_ops {
+    assert(wop.name != nil && wop.name != "", "webhook operation missing name")
+    assert(wop.method != nil && wop.method != "", "webhook operation missing method")
+    assert(type_of(wop.path_item) == "dict", "webhook operation path_item must be a dict")
+    assert(type_of(wop.operation) == "dict", "webhook operation operation must be a dict")
+  }
+  // Locate the commentCreated webhook and verify its payload schema resolves.
+  var comment_created = nil
+  for wop in webhook_ops {
+    if wop.name == "commentCreated" {
+      comment_created = wop
+    }
+  }
+  assert(comment_created != nil, "could not find commentCreated webhook")
+  println("commentCreated: ${comment_created.method} -> ${comment_created.operation_id}")
+  let req_body = comment_created.operation.get("requestBody")
+  assert(req_body != nil, "commentCreated webhook must declare a requestBody")
+  let payload_schema_raw = req_body.content["application/json"].schema
+  let resolved = schema(doc, payload_schema_raw)
+  assert(type_of(resolved) == "dict", "resolved webhook schema must be a dict")
+  // The Notion webhook envelope shape should expose common event fields
+  // once the $ref is resolved. Accept either `properties` or `allOf`
+  // composed schemas — just assert we got something non-empty back.
+  let has_props = resolved.get("properties") != nil
+  let has_oneof = resolved.get("oneOf") != nil
+  let has_allof = resolved.get("allOf") != nil
+  let has_anyof = resolved.get("anyOf") != nil
+  let has_type = resolved.get("type") != nil
+  assert(
+    has_props || has_oneof || has_allof || has_anyof || has_type,
+    "resolved commentCreated payload schema must expose properties/oneOf/allOf/anyOf/type",
+  )
+  if has_props {
+    let field_names = resolved.properties.keys()
+    println("commentCreated payload fields: ${len(field_names)}")
+  }
+  println("webhook_smoke: ok")
+}


### PR DESCRIPTION
## Summary

OpenAPI 3.1 makes `webhooks` first-class and adds `components.pathItems`, but `parse()` was silently dropping both and `operations()` only walked `paths`. The pinned Notion fixture already exercises 31 webhooks — a "pure-Harn OpenAPI 3.1 parser" that never surfaces them is selling itself short of its version number.

Closes #2.

## Changes

- `parse()` now includes `webhooks` (`dict<string, PathItem>`) and normalizes `components.pathItems` onto the returned doc. Both are always dicts on the parsed doc, even when the source omits them.
- `webhook_operations(doc) -> list` flattens `doc.webhooks` analogously to `operations()`. Entries expose `{ name, method, path_item, operation, operation_id, summary, parameters, request_body, responses, security, tags }`. `name` is the webhook key (e.g. `commentCreated`) so downstream connectors can route inbound payloads.
- `component_path_items(doc) -> dict<string, PathItem>` is a thin passthrough for `doc.components.pathItems`.
- `operations()` and `webhook_operations()` now share a private `_flatten_path_item_map` helper to stay DRY.
- New `tests/webhook_smoke.harn` asserts the webhook count (>= 10 on Notion; observed: 31), verifies every entry's shape, and resolves the `commentCreated` payload schema through `schema()`.
- README's "exported surface" section mentions both new helpers alongside existing ones.

Codegen changes (`webhook_handlers` option on `codegen_module()`) are intentionally deferred per the issue — this PR keeps the ticket tight.

## Acceptance (from #2)

- [x] `parse()` surfaces `webhooks` and `components.pathItems` on the returned doc.
- [x] `webhook_operations(doc)` returns >= 10 entries on the Notion fixture (observed: 31).
- [x] `tests/webhook_smoke.harn` asserts webhook count and verifies one handler's payload schema resolves.
- [x] README's "exported surface" section mentions both helpers.
- [x] Doesn't break M1–M3 smoke tests.

## Test plan

- [x] `harn check src/lib.harn` — ok
- [x] `harn lint src/lib.harn` — no issues
- [x] `harn fmt --check src/lib.harn tests/webhook_smoke.harn` — clean
- [x] `harn run tests/parse_smoke.harn` — ok (46 operations, 503 schemas)
- [x] `harn run tests/walk_smoke.harn` — ok (query op resolves, enum found)
- [x] `harn run tests/codegen_smoke.harn` — ok (generated SDK passes `harn check`)
- [x] `harn run tests/webhook_smoke.harn` — ok (31 webhooks, 31 webhook operations, commentCreated resolves to a 13-field payload)

Pre-existing `assert-outside-test` lint warnings on the new file match the convention of `parse_smoke.harn` / `walk_smoke.harn` / `codegen_smoke.harn`; no new lint regressions.