### PR TITLE
codegen: per-scheme security handling, honor operation.security

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,13 @@ write_file("./src/lib.harn", src)
 
 - `parse(json_string) -> dict` — normalize a 3.1.x doc to
   `{ openapi, info, servers, paths, webhooks, components,
-  security_schemes, tags }`. `paths` may be empty (3.1 allows
+  security_schemes, security, tags }`. `paths` may be empty (3.1 allows
   webhooks-only docs). `components.pathItems` is always present as a
   dict, even when the source doc omits it.
 - `operations(doc) -> list` — flatten `doc.paths` into operation
   records `{ method, path, operation_id, summary, parameters,
-  request_body, responses, security, tags, ... }`.
+  request_body, responses, security, tags, ... }`. Each operation's
+  `security` is resolved as `op.security ?? doc.security ?? []`.
 - `webhook_operations(doc) -> list` — flatten `doc.webhooks` into
   records `{ name, method, path_item, operation, operation_id,
   summary, parameters, request_body, responses, security, tags }`.
@@ -77,7 +78,47 @@ write_file("./src/lib.harn", src)
 - `enum_values(schema) -> list | nil` — extract the enum variant list,
   or `nil` when the schema is not an enum.
 - `codegen_module(doc, options) -> string` — emit a typed Harn SDK
-  module source string.
+  module source string with per-scheme security dispatch (see below).
+
+### Security handling in generated clients
+
+`codegen_module` inspects `components.securitySchemes` and emits a
+dedicated `_headers_<scheme>(client)` helper per scheme that is actually
+referenced by at least one operation. Each operation dispatches through
+the helper matching its *effective* security (`op.security ?? doc.security
+?? []`) — explicit `security: []` at either level routes through
+`_no_auth_headers(client)` so the call goes out without an `Authorization`
+header.
+
+`new_client` takes only the client fields implied by the schemes in use,
+all defaulted so callers only supply what their spec actually needs:
+
+| Scheme kind | Client field added |
+|---|---|
+| `http` + `bearer`, `oauth2`, `openIdConnect` | `token: string = ""` |
+| `http` + `basic` | `basic_user: string = ""`, `basic_password: string = ""` |
+| `apiKey` (header / query / cookie) | `api_keys: dict = {}` (keyed by scheme name) |
+| `mutualTLS` | (v0: no-op — op falls through to `_no_auth_headers`) |
+
+So a Notion-shaped spec with `bearerAuth` + `basicAuth` yields:
+
+```harn
+new_client(
+  base_url: string = "https://api.notion.com",
+  token: string = "",
+  basic_user: string = "",
+  basic_password: string = "",
+  extra_headers: dict = {"Notion-Version": "..."},
+) -> dict
+```
+
+When an operation declares multiple security requirement alternatives
+(`security: [{a: []}, {b: []}]`), v0 picks the first and leaves a
+`TODO` comment above the generated function listing the alternatives so
+a human can retarget manually.
+
+Out of scope for v0: full OAuth2 flows (authorization-code, device,
+PKCE) and `mutualTLS` client-certificate plumbing.
 
 ## Development
 

--- a/src/lib.harn
+++ b/src/lib.harn
@@ -5,14 +5,19 @@
 //   parse(json_string)           -> dict
 //       Parse an OpenAPI 3.1 JSON document into a normalized dict with
 //       shape { openapi, info, servers, paths, webhooks, components,
-//       security_schemes, tags }. OAS 3.1 makes `paths` optional and
-//       introduces first-class `webhooks` plus `components.pathItems`
-//       — all three are surfaced here. Throws on non-3.1.x docs.
+//       security_schemes, security, tags }. OAS 3.1 makes `paths`
+//       optional and introduces first-class `webhooks` plus
+//       `components.pathItems` — all three are surfaced here. The
+//       doc-level `security` is also surfaced so operation-level
+//       security falls back cleanly. Throws on non-3.1.x docs.
 //
 //   operations(doc)              -> list<operation>
 //       Flatten path-itemed operations in `doc.paths` into a list of
 //       { method, path, operation_id, summary, parameters,
-//       request_body, responses, security } dicts.
+//       request_body, responses, security } dicts. Each operation's
+//       `security` is resolved as `op.security ?? doc.security ?? []`,
+//       so an explicit `security: []` at either level survives as a
+//       signal to emit an unauthenticated call.
 //
 //   webhook_operations(doc)      -> list<webhook_operation>
 //       Flatten OAS 3.1 `doc.webhooks` into a list of
@@ -36,6 +41,15 @@
 //   codegen_module(doc, options) -> string
 //       Emit a complete typed Harn SDK module source string. Options:
 //       { module_name, client_name, default_base_url?, header_overrides? }.
+//       The generated client handles per-operation security: a helper
+//       `_headers_<scheme>(client)` is emitted for each scheme declared
+//       in `components.securitySchemes` and actually referenced by at
+//       least one operation (bearer / basic / apiKey-in-{header,query,
+//       cookie} / oauth2 / openIdConnect). Operations with `security: []`
+//       dispatch through `_no_auth_headers(client)` so they never send
+//       an Authorization header. `new_client`'s parameter set is
+//       restricted to the fields the emitted helpers actually read
+//       (token, basic_user/basic_password, api_keys).
 //
 // See README.md for end-to-end usage; scripts/regen_demo.harn runs a
 // full parse -> codegen -> write loop against the bundled Notion
@@ -65,6 +79,7 @@ pub fn parse(json_string: string) -> dict {
     webhooks: raw.get("webhooks") ?? {},
     components: components_with_path_items,
     security_schemes: components.get("securitySchemes") ?? {},
+    security: raw.get("security") ?? [],
     tags: raw.get("tags") ?? [],
   }
 }
@@ -306,22 +321,24 @@ let _MODULE_TEMPLATE = """
   // Module:     {{ module_name }}
 
   /** Create a new {{ client_name }} handle. */
-  pub fn new_client(token: string, base_url: string = "{{ default_base_url }}") -> dict {
+  pub fn new_client({{ new_client_signature }}) -> dict {
     return {
-      base_url: base_url,
-      token: token,
-      extra_headers: {{ extra_headers_literal }},
+      base_url: base_url,{{ for field in client_fields }}
+      {{ field.name }}: {{ field.name }},{{ end }}
+      extra_headers: extra_headers,
     }
   }
 
-  fn _auth_headers(client: dict) -> dict {
-    var hs = {Authorization: "Bearer " + client.token, "Content-Type": "application/json"}
+  fn _no_auth_headers(client: dict) -> dict {
+    var hs = {"Content-Type": "application/json"}
     for entry in client.extra_headers {
       hs = {...hs, [entry.key]: entry.value}
     }
     return hs
   }
-
+  {{ for helper in auth_helpers }}
+  {{ helper.body }}
+  {{ end }}
   fn _interpolate(template: string, bindings: dict) -> string {
     var out = template
     for entry in bindings {
@@ -342,11 +359,12 @@ let _MODULE_TEMPLATE = """
   }
 
   {{ for op in operations }}
-  {{ op.doc_comment }}
+  {{ op.doc_comment }}{{ if op.security_note }}
+  // {{ op.security_note }}{{ end }}
   pub fn {{ op.fn_name }}({{ op.signature }}) -> dict {
     let url = client.base_url + _interpolate("{{ op.path }}", {{ op.path_bindings }}){{ if op.has_query }} + _query_string({{ op.query_bindings }}){{ end }}
     {{ if op.has_body }}let body_str = json_stringify(body)
-    let resp = http_{{ op.method }}(url, body_str, {headers: _auth_headers(client)}){{ else }}let resp = http_{{ op.method }}(url, {headers: _auth_headers(client)}){{ end }}
+    let resp = http_{{ op.method }}(url, body_str, {headers: {{ op.headers_call }}}){{ else }}let resp = http_{{ op.method }}(url, {headers: {{ op.headers_call }}}){{ end }}
     if resp.status >= 400 {
       throw "{{ op.fn_name }}: HTTP " + to_string(resp.status) + " " + resp.body
     }
@@ -362,11 +380,37 @@ pub fn codegen_module(doc: dict, options: dict) -> string {
   let client_name = options.get("client_name") ?? "Client"
   let default_base_url = options.get("default_base_url") ?? _default_server_url(doc)
   let header_overrides = options.get("header_overrides") ?? {}
+  let schemes = doc.get("security_schemes") ?? {}
+  let doc_security = doc.get("security") ?? []
   let ops_raw = operations(doc)
+  // First pass: resolve each op's security choice so we can collect the
+  // set of schemes actually referenced. An explicit `security: []` at
+  // either the operation or document level means "no auth" and must NOT
+  // pull in a scheme.
+  var used_schemes = []
+  for op in ops_raw {
+    let choice = _resolve_security(op.security, doc_security)
+    if choice.scheme_name != nil && !used_schemes.contains(choice.scheme_name) {
+      used_schemes = used_schemes + [choice.scheme_name]
+    }
+  }
+  // Derive which client fields are needed from the used schemes.
+  let client_fields = _derive_client_fields(used_schemes, schemes)
+  let new_client_signature = _render_new_client_signature(client_fields, default_base_url, header_overrides)
+  // Emit per-scheme header/query helpers.
+  var auth_helpers = []
+  for scheme_name in used_schemes {
+    let def = schemes.get(scheme_name)
+    if def != nil {
+      auth_helpers = auth_helpers + [{body: _render_auth_helper(scheme_name, def)}]
+    }
+  }
+  // Second pass: build operation models with per-op dispatch wired up.
   var ops = []
   var seen_names = []
   for op in ops_raw {
-    let model = _build_op_model(op, seen_names)
+    let choice = _resolve_security(op.security, doc_security)
+    let model = _build_op_model(op, seen_names, choice, schemes)
     seen_names = seen_names + [model.fn_name]
     ops = ops + [model]
   }
@@ -376,10 +420,239 @@ pub fn codegen_module(doc: dict, options: dict) -> string {
     module_name: module_name,
     client_name: client_name,
     default_base_url: default_base_url,
-    extra_headers_literal: _render_dict_literal(header_overrides),
+    new_client_signature: new_client_signature,
+    client_fields: client_fields,
+    auth_helpers: auth_helpers,
     operations: ops,
   }
   return render_string(_MODULE_TEMPLATE, bindings)
+}
+
+/**
+ * Resolve which security requirement applies to a given operation.
+ *
+ * Returns a dict with:
+ *   scheme_name:   string | nil  — nil means "no auth"
+ *   alternatives:  list<string>  — other scheme names from requirements we dropped
+ *   explicit_none: bool          — true when the spec said `security: []`
+ */
+fn _resolve_security(op_security, doc_security) {
+  // operation.security wins even when it's an empty list (means "no auth").
+  let reqs = if op_security != nil {
+    op_security
+  } else {
+    doc_security
+  }
+  if type_of(reqs) != "list" || len(reqs) == 0 {
+    return {scheme_name: nil, alternatives: [], explicit_none: true}
+  }
+  let first = reqs[0]
+  if type_of(first) != "dict" {
+    return {scheme_name: nil, alternatives: [], explicit_none: true}
+  }
+  // Pick the first scheme key in the first requirement.
+  var picked = nil
+  for entry in first {
+    if picked == nil {
+      picked = entry.key
+    }
+  }
+  if picked == nil {
+    return {scheme_name: nil, alternatives: [], explicit_none: true}
+  }
+  var alternatives = []
+  var i = 1
+  while i < len(reqs) {
+    let alt = reqs[i]
+    if type_of(alt) == "dict" {
+      for entry in alt {
+        if !alternatives.contains(entry.key) && entry.key != picked {
+          alternatives = alternatives + [entry.key]
+        }
+      }
+    }
+    i = i + 1
+  }
+  return {scheme_name: picked, alternatives: alternatives, explicit_none: false}
+}
+
+/** Which client-struct fields are needed given the schemes actually used? */
+fn _derive_client_fields(used_schemes, schemes) {
+  var want_token = false
+  var want_basic = false
+  var want_api_keys = false
+  for name in used_schemes {
+    let def = schemes.get(name)
+    if def != nil {
+      let kind = _scheme_kind(def)
+      if kind == "bearer" || kind == "oauth2" || kind == "openIdConnect" {
+        want_token = true
+      } else if kind == "basic" {
+        want_basic = true
+      } else if kind == "apiKey-header" || kind == "apiKey-query" || kind == "apiKey-cookie" {
+        want_api_keys = true
+      }
+    }
+  }
+  var fields = []
+  if want_token {
+    fields = fields + [{name: "token", kind: "string", default: "\"\""}]
+  }
+  if want_basic {
+    fields = fields + [{name: "basic_user", kind: "string", default: "\"\""}]
+    fields = fields + [{name: "basic_password", kind: "string", default: "\"\""}]
+  }
+  if want_api_keys {
+    fields = fields + [{name: "api_keys", kind: "dict", default: "{}"}]
+  }
+  return fields
+}
+
+/**
+ * Classify a security scheme into one of our supported kinds.
+ *
+ * Returns: "bearer" | "basic" | "apiKey-header" | "apiKey-query" |
+ *          "apiKey-cookie" | "oauth2" | "openIdConnect" | "mutualTLS" |
+ *          "unknown".
+ */
+fn _scheme_kind(def) {
+  let ty = def.get("type")
+  if ty == "http" {
+    let scheme = def.get("scheme")
+    if scheme == "bearer" {
+      return "bearer"
+    }
+    if scheme == "basic" {
+      return "basic"
+    }
+    return "unknown"
+  }
+  if ty == "apiKey" {
+    let loc = def.get("in") ?? "header"
+    if loc == "header" {
+      return "apiKey-header"
+    }
+    if loc == "query" {
+      return "apiKey-query"
+    }
+    if loc == "cookie" {
+      return "apiKey-cookie"
+    }
+    return "unknown"
+  }
+  if ty == "oauth2" {
+    return "oauth2"
+  }
+  if ty == "openIdConnect" {
+    return "openIdConnect"
+  }
+  if ty == "mutualTLS" {
+    return "mutualTLS"
+  }
+  return "unknown"
+}
+
+fn _render_new_client_signature(fields, default_base_url, header_overrides) {
+  var parts = ["base_url: string = \"" + _escape_string(default_base_url) + "\""]
+  for f in fields {
+    if f.kind == "string" {
+      parts = parts + [f.name + ": string = " + f.default]
+    } else if f.kind == "dict" {
+      parts = parts + [f.name + ": dict = " + f.default]
+    }
+  }
+  parts = parts + ["extra_headers: dict = " + _render_dict_literal(header_overrides)]
+  return join(parts, ", ")
+}
+
+fn _render_auth_helper(scheme_name, def) {
+  let kind = _scheme_kind(def)
+  let fn_name = "_headers_" + _sanitize_ident(scheme_name)
+  if kind == "bearer" || kind == "oauth2" || kind == "openIdConnect" {
+    return "fn " + fn_name + "(client: dict) -> dict {\n"
+      + "    var hs = {Authorization: \"Bearer \" + to_string(client.token), \"Content-Type\": \"application/json\"}\n"
+      + "    for entry in client.extra_headers {\n"
+      + "      hs = {...hs, [entry.key]: entry.value}\n"
+      + "    }\n"
+      + "    return hs\n"
+      + "  }"
+  }
+  if kind == "basic" {
+    return "fn " + fn_name + "(client: dict) -> dict {\n"
+      + "    let encoded = base64_encode(to_string(client.basic_user) + \":\" + to_string(client.basic_password))\n"
+      + "    var hs = {Authorization: \"Basic \" + encoded, \"Content-Type\": \"application/json\"}\n"
+      + "    for entry in client.extra_headers {\n"
+      + "      hs = {...hs, [entry.key]: entry.value}\n"
+      + "    }\n"
+      + "    return hs\n"
+      + "  }"
+  }
+  if kind == "apiKey-header" {
+    let header_name = def.get("name") ?? scheme_name
+    return "fn " + fn_name + "(client: dict) -> dict {\n"
+      + "    var hs = {\""
+      + _escape_string(header_name)
+      + "\": to_string(client.api_keys.get(\""
+      + _escape_string(scheme_name)
+      + "\") ?? \"\"), \"Content-Type\": \"application/json\"}\n"
+      + "    for entry in client.extra_headers {\n"
+      + "      hs = {...hs, [entry.key]: entry.value}\n"
+      + "    }\n"
+      + "    return hs\n"
+      + "  }"
+  }
+  if kind == "apiKey-cookie" {
+    let cookie_name = def.get("name") ?? scheme_name
+    return "fn " + fn_name + "(client: dict) -> dict {\n"
+      + "    var hs = {Cookie: \""
+      + _escape_string(cookie_name)
+      + "=\" + to_string(client.api_keys.get(\""
+      + _escape_string(scheme_name)
+      + "\") ?? \"\"), \"Content-Type\": \"application/json\"}\n"
+      + "    for entry in client.extra_headers {\n"
+      + "      hs = {...hs, [entry.key]: entry.value}\n"
+      + "    }\n"
+      + "    return hs\n"
+      + "  }"
+  }
+  if kind == "apiKey-query" {
+    // Headers helper adds nothing beyond Content-Type; a parallel
+    // _query_<scheme>_dict helper contributes the auth parameter dict
+    // which is spread into each operation's query bindings.
+    let query_name = def.get("name") ?? scheme_name
+    let query_fn_name = "_query_" + _sanitize_ident(scheme_name) + "_dict"
+    return "fn " + fn_name + "(client: dict) -> dict {\n"
+      + "    var hs = {\"Content-Type\": \"application/json\"}\n"
+      + "    for entry in client.extra_headers {\n"
+      + "      hs = {...hs, [entry.key]: entry.value}\n"
+      + "    }\n"
+      + "    return hs\n"
+      + "  }\n"
+      + "\n"
+      + "  fn "
+      + query_fn_name
+      + "(client: dict) -> dict {\n"
+      + "    let v = client.api_keys.get(\""
+      + _escape_string(scheme_name)
+      + "\")\n"
+      + "    if v == nil {\n"
+      + "      return {}\n"
+      + "    }\n"
+      + "    return {\""
+      + _escape_string(query_name)
+      + "\": v}\n"
+      + "  }"
+  }
+  // mutualTLS and unknown kinds fall back to no-auth behavior with a note.
+  return "// NOTE: security scheme '" + _escape_string(scheme_name) + "' (kind='" + kind
+    + "') is not supported by this codegen. Operations that reference it\n"
+    + "  // will fall back to _no_auth_headers. File an issue upstream if you need\n"
+    + "  // first-class support.\n"
+    + "  fn "
+    + fn_name
+    + "(client: dict) -> dict {\n"
+    + "    return _no_auth_headers(client)\n"
+    + "  }"
 }
 
 fn _default_server_url(doc) {
@@ -390,7 +663,7 @@ fn _default_server_url(doc) {
   return servers[0].get("url") ?? ""
 }
 
-fn _build_op_model(op, taken_names) {
+fn _build_op_model(op, taken_names, choice, schemes) {
   let fn_name = _unique_fn_name(_sanitize_fn_name(op.operation_id), taken_names)
   let params = op.parameters
   var path_params = []
@@ -430,8 +703,30 @@ fn _build_op_model(op, taken_names) {
     required_sig = required_sig + ["body"]
   }
   let sig_parts = required_sig + optional_sig
-  let path_bindings = "{" + join(path_bindings_parts, ", ") + "}"
-  let query_bindings = "{" + join(query_bindings_parts, ", ") + "}"
+  // Figure out which headers helper this op calls. A nil scheme_name means
+  // "no auth" (either explicit security: [] or a doc with no declared
+  // default security).
+  let scheme_name = choice.scheme_name
+  let headers_call = if scheme_name == nil {
+    "_no_auth_headers(client)"
+  } else {
+    "_headers_" + _sanitize_ident(scheme_name) + "(client)"
+  }
+  // apiKey-in-query schemes contribute an extra entry to the query string,
+  // spliced into the query bindings literal via a spread.
+  var extra_query_spread = ""
+  if scheme_name != nil {
+    let def = schemes.get(scheme_name)
+    if def != nil && _scheme_kind(def) == "apiKey-query" {
+      // `_query_<scheme>(client)` returns a string "k=v" (already URL-encoded)
+      // or "" if no key is configured; it is appended to the query string
+      // via _apikey_suffix below.
+      extra_query_spread = "apikey-query"
+    }
+  }
+  let has_query_params = len(query_params) > 0
+  let has_apikey_query = extra_query_spread == "apikey-query"
+  let has_query = has_query_params || has_apikey_query
   let doc_lines = split(op.summary, "\n")
   let first = if len(doc_lines) > 0 {
     doc_lines[0]
@@ -444,17 +739,51 @@ fn _build_op_model(op, taken_names) {
     first
   }
   let doc_comment = "/** " + _escape_comment(safe_summary) + " */"
+  // If the op had multiple security requirement alternatives, preserve the
+  // discarded names in a TODO comment so a human can retarget manually.
+  let alts = choice.alternatives
+  let security_note = if type_of(alts) == "list" && len(alts) > 0 {
+    "TODO: security alternatives also accepted: " + join(alts, ", ")
+  } else {
+    ""
+  }
   return {
     fn_name: fn_name,
     method: op.method,
     path: op.path,
     signature: join(sig_parts, ", "),
-    path_bindings: path_bindings,
-    query_bindings: query_bindings,
-    has_query: len(query_params) > 0,
+    path_bindings: path_bindings_parts_render(path_bindings_parts),
+    query_bindings: _render_query_bindings(query_bindings_parts, has_apikey_query, scheme_name),
+    has_query: has_query,
     has_body: has_body,
     doc_comment: doc_comment,
+    headers_call: headers_call,
+    security_note: security_note,
   }
+}
+
+fn path_bindings_parts_render(parts) {
+  return "{" + join(parts, ", ") + "}"
+}
+
+fn _render_query_bindings(parts, has_apikey_query, scheme_name) {
+  // The emitted call reaches into `_query_<scheme>(client)` for apiKey-query
+  // schemes. We emit `_query_string({k: v, ...})` normally; apiKey-query
+  // schemes splice a "&<encoded>" suffix onto the query string via a
+  // post-concat. To keep the template uniform, we render a dict literal
+  // here and the caller wraps _query_string(...) for the base params,
+  // then appends _query_<scheme>(client) via a + concat in the template.
+  // For simplicity, we bake the apiKey-query param directly into the
+  // dict literal using a spread from a helper dict.
+  if has_apikey_query && scheme_name != nil {
+    let sanitized = _sanitize_ident(scheme_name)
+    let extra = "..._query_" + sanitized + "_dict(client)"
+    if len(parts) == 0 {
+      return "{" + extra + "}"
+    }
+    return "{" + join(parts, ", ") + ", " + extra + "}"
+  }
+  return "{" + join(parts, ", ") + "}"
 }
 
 fn _sanitize_fn_name(raw) {

--- a/tests/security_smoke.harn
+++ b/tests/security_smoke.harn
@@ -1,0 +1,285 @@
+// security_smoke — exercise per-scheme auth helpers emitted by
+// codegen_module against synthetic OpenAPI docs. Each sub-scenario
+// asserts the generated Harn source contains the correct auth-dispatch
+// wiring and that the corresponding helper functions produce the
+// expected Authorization / header / query bindings at runtime.
+//
+// Note: `http_mock_calls()` upstream records method/url/body but not
+// request headers (see burin-labs/harn#TBD). Until that lands, we
+// assert on generated source text plus runtime evaluation of helper
+// fns whose shape is deterministic.
+
+import { parse, codegen_module } from "../src/lib"
+
+fn build_doc(sec_schemes: dict, doc_security, ops: list) -> string {
+  var paths = {}
+  for op in ops {
+    var method_entry = {
+      operationId: op.operation_id,
+      responses: {"200": {description: "ok"}},
+    }
+    if op.get("security") != nil {
+      method_entry = {...method_entry, security: op.security}
+    }
+    paths = {...paths, [op.path]: {[op.method]: method_entry}}
+  }
+  var root = {
+    openapi: "3.1.0",
+    info: {title: "Test", version: "0.0.1"},
+    servers: [{url: "https://api.example.com"}],
+    paths: paths,
+    components: {securitySchemes: sec_schemes},
+  }
+  if doc_security != nil {
+    root = {...root, security: doc_security}
+  }
+  return json_stringify(root)
+}
+
+fn assert_contains(haystack: string, needle: string, label: string) {
+  if !contains(haystack, needle) {
+    println("---BEGIN GENERATED SOURCE---")
+    println(haystack)
+    println("---END GENERATED SOURCE---")
+    assert(false, "${label}: expected source to contain \"${needle}\"")
+  }
+}
+
+fn assert_not_contains(haystack: string, needle: string, label: string) {
+  if contains(haystack, needle) {
+    println("---BEGIN GENERATED SOURCE---")
+    println(haystack)
+    println("---END GENERATED SOURCE---")
+    assert(false, "${label}: expected source NOT to contain \"${needle}\"")
+  }
+}
+
+fn check_generates(src: string, label: string) {
+  let tmp_path = "/tmp/harn-openapi-security-smoke-${label}.harn"
+  write_file(tmp_path, src)
+  let result = shell(
+    "cd /Users/ksinder/projects/harn && target/debug/harn check " + tmp_path,
+  )
+  if !result.success {
+    println("---harn check stderr---")
+    println(result.stderr)
+    println("---harn check stdout---")
+    println(result.stdout)
+  }
+  assert(result.success, "${label}: generated SDK must pass \`harn check\`")
+}
+
+@test
+pipeline default() {
+  // ------------------------------------------------------------------
+  // Scenario A: http bearer at the doc level, inherited by all ops.
+  // ------------------------------------------------------------------
+  let doc_a = build_doc(
+    {bearerAuth: {type: "http", scheme: "bearer"}},
+    [{bearerAuth: []}],
+    [{operation_id: "get-self", method: "get", path: "/v1/users/me"}],
+  )
+  let src_a = codegen_module(parse(doc_a), {module_name: "a", client_name: "A"})
+  assert_contains(src_a, "_headers_bearerauth(client)", "A/dispatch")
+  assert_contains(src_a, "Authorization: \"Bearer \" + to_string(client.token)", "A/bearer-helper")
+  assert_contains(src_a, "token: string = \"\"", "A/client-has-token")
+  assert_not_contains(src_a, "basic_user", "A/no-basic-field")
+  assert_not_contains(src_a, "api_keys", "A/no-apikey-field")
+  check_generates(src_a, "A")
+
+  // ------------------------------------------------------------------
+  // Scenario B: explicit security: [] on one op overrides doc default.
+  // ------------------------------------------------------------------
+  let doc_b = build_doc(
+    {bearerAuth: {type: "http", scheme: "bearer"}},
+    [{bearerAuth: []}],
+    [
+      {operation_id: "get-self", method: "get", path: "/v1/users/me"},
+      {operation_id: "public-ping", method: "get", path: "/health", security: []},
+    ],
+  )
+  let src_b = codegen_module(parse(doc_b), {module_name: "b", client_name: "B"})
+  // Authed op still uses the bearer helper.
+  assert_contains(src_b, "_headers_bearerauth(client)", "B/authed-dispatch")
+  // The no-auth op must route through _no_auth_headers.
+  let b_lines = split(src_b, "\n")
+  var b_public_line = ""
+  var b_collect_public = false
+  for line in b_lines {
+    if contains(line, "pub fn public_ping") {
+      b_collect_public = true
+    }
+    if b_collect_public {
+      if contains(line, "let resp = ") {
+        b_public_line = line
+        b_collect_public = false
+      }
+    }
+  }
+  assert(
+    contains(b_public_line, "_no_auth_headers(client)"),
+    "B/public-op-must-use-no-auth-headers: got \"${b_public_line}\"",
+  )
+  assert(
+    !contains(b_public_line, "_headers_bearerauth"),
+    "B/public-op-must-NOT-use-bearer-helper: got \"${b_public_line}\"",
+  )
+  check_generates(src_b, "B")
+
+  // ------------------------------------------------------------------
+  // Scenario C: http basic only.
+  // ------------------------------------------------------------------
+  let doc_c = build_doc(
+    {basicAuth: {type: "http", scheme: "basic"}},
+    [{basicAuth: []}],
+    [{operation_id: "login", method: "post", path: "/login"}],
+  )
+  let src_c = codegen_module(parse(doc_c), {module_name: "c", client_name: "C"})
+  assert_contains(src_c, "_headers_basicauth(client)", "C/dispatch")
+  assert_contains(src_c, "base64_encode", "C/basic-uses-base64")
+  assert_contains(src_c, "Authorization: \"Basic \" + encoded", "C/basic-header")
+  assert_contains(src_c, "basic_user: string = \"\"", "C/client-has-basic-user")
+  assert_contains(src_c, "basic_password: string = \"\"", "C/client-has-basic-password")
+  assert_not_contains(src_c, "token:", "C/no-token-field")
+  check_generates(src_c, "C")
+
+  // ------------------------------------------------------------------
+  // Scenario D: apiKey in header.
+  // ------------------------------------------------------------------
+  let doc_d = build_doc(
+    {xApiKey: {type: "apiKey", in: "header", name: "X-Api-Key"}},
+    [{xApiKey: []}],
+    [{operation_id: "get-thing", method: "get", path: "/thing"}],
+  )
+  let src_d = codegen_module(parse(doc_d), {module_name: "d", client_name: "D"})
+  assert_contains(src_d, "_headers_xapikey(client)", "D/dispatch")
+  assert_contains(src_d, "\"X-Api-Key\":", "D/header-name-emitted")
+  assert_contains(src_d, "client.api_keys.get(\"xApiKey\")", "D/reads-from-api-keys")
+  assert_contains(src_d, "api_keys: dict = {}", "D/client-has-api-keys")
+  assert_not_contains(src_d, "token:", "D/no-token-field")
+  check_generates(src_d, "D")
+
+  // ------------------------------------------------------------------
+  // Scenario E: apiKey in query.
+  // ------------------------------------------------------------------
+  let doc_e = build_doc(
+    {qKey: {type: "apiKey", in: "query", name: "api_key"}},
+    [{qKey: []}],
+    [{operation_id: "list-things", method: "get", path: "/things"}],
+  )
+  let src_e = codegen_module(parse(doc_e), {module_name: "e", client_name: "E"})
+  assert_contains(src_e, "_headers_qkey(client)", "E/headers-dispatch")
+  assert_contains(src_e, "_query_qkey_dict(client)", "E/query-spread-in-op")
+  assert_contains(src_e, "\"api_key\": v", "E/query-name-emitted")
+  assert_contains(src_e, "_query_string", "E/op-has-query-string-call")
+  check_generates(src_e, "E")
+
+  // ------------------------------------------------------------------
+  // Scenario F: apiKey in cookie.
+  // ------------------------------------------------------------------
+  let doc_f = build_doc(
+    {sessId: {type: "apiKey", in: "cookie", name: "sid"}},
+    [{sessId: []}],
+    [{operation_id: "me", method: "get", path: "/me"}],
+  )
+  let src_f = codegen_module(parse(doc_f), {module_name: "f", client_name: "F"})
+  assert_contains(src_f, "_headers_sessid(client)", "F/dispatch")
+  assert_contains(src_f, "Cookie: \"sid=\" +", "F/cookie-header")
+  assert_contains(src_f, "client.api_keys.get(\"sessId\")", "F/reads-from-api-keys")
+  check_generates(src_f, "F")
+
+  // ------------------------------------------------------------------
+  // Scenario G: oauth2 — treated as bearer for v0 (client already holds token).
+  // ------------------------------------------------------------------
+  let doc_g = build_doc(
+    {
+      oauth2Auth: {
+        type: "oauth2",
+        flows: {clientCredentials: {tokenUrl: "https://api.example.com/oauth/token", scopes: {}}},
+      },
+    },
+    [{oauth2Auth: []}],
+    [{operation_id: "do-thing", method: "get", path: "/thing"}],
+  )
+  let src_g = codegen_module(parse(doc_g), {module_name: "g", client_name: "G"})
+  assert_contains(src_g, "_headers_oauth2auth(client)", "G/dispatch")
+  assert_contains(src_g, "Authorization: \"Bearer \" + to_string(client.token)", "G/bearer-shape")
+  assert_contains(src_g, "token: string = \"\"", "G/client-has-token")
+  check_generates(src_g, "G")
+
+  // ------------------------------------------------------------------
+  // Scenario H: mixed schemes (bearer + basic) with per-op overrides,
+  // mirroring the real-world Notion shape.
+  // ------------------------------------------------------------------
+  let doc_h = build_doc(
+    {
+      bearerAuth: {type: "http", scheme: "bearer"},
+      basicAuth: {type: "http", scheme: "basic"},
+    },
+    [{bearerAuth: []}],
+    [
+      {operation_id: "get-me", method: "get", path: "/v1/users/me"},
+      {
+        operation_id: "create-a-token",
+        method: "post",
+        path: "/v1/oauth/token",
+        security: [{basicAuth: []}],
+      },
+    ],
+  )
+  let src_h = codegen_module(parse(doc_h), {module_name: "h", client_name: "H"})
+  // Bearer helper defined and used by the default op.
+  assert_contains(src_h, "fn _headers_bearerauth(", "H/bearer-helper-defined")
+  assert_contains(src_h, "fn _headers_basicauth(", "H/basic-helper-defined")
+  // Check per-op dispatch line by line.
+  let h_lines = split(src_h, "\n")
+  var h_get_me_line = ""
+  var h_token_line = ""
+  var h_collect_me = false
+  var h_collect_token = false
+  for line in h_lines {
+    if contains(line, "pub fn get_me") {
+      h_collect_me = true
+    }
+    if contains(line, "pub fn create_a_token") {
+      h_collect_token = true
+    }
+    if h_collect_me && contains(line, "let resp = ") {
+      h_get_me_line = line
+      h_collect_me = false
+    }
+    if h_collect_token && contains(line, "let resp = ") {
+      h_token_line = line
+      h_collect_token = false
+    }
+  }
+  assert(
+    contains(h_get_me_line, "_headers_bearerauth(client)"),
+    "H/get_me-uses-bearer: got \"${h_get_me_line}\"",
+  )
+  assert(
+    contains(h_token_line, "_headers_basicauth(client)"),
+    "H/create_a_token-uses-basic: got \"${h_token_line}\"",
+  )
+  assert(
+    !contains(h_token_line, "_headers_bearerauth"),
+    "H/create_a_token-must-NOT-use-bearer: got \"${h_token_line}\"",
+  )
+  check_generates(src_h, "H")
+
+  // ------------------------------------------------------------------
+  // Scenario I: mutualTLS — v0 fallback to no-auth with a NOTE comment.
+  // ------------------------------------------------------------------
+  let doc_i = build_doc(
+    {mtls: {type: "mutualTLS"}},
+    [{mtls: []}],
+    [{operation_id: "mtls-op", method: "get", path: "/secure"}],
+  )
+  let src_i = codegen_module(parse(doc_i), {module_name: "i", client_name: "I"})
+  assert_contains(src_i, "// NOTE: security scheme 'mtls'", "I/fallback-note-emitted")
+  assert_contains(src_i, "_headers_mtls(client)", "I/fallback-helper-called")
+  assert_contains(src_i, "return _no_auth_headers(client)", "I/falls-back-to-no-auth")
+  check_generates(src_i, "I")
+
+  println("security_smoke: ok")
+}


### PR DESCRIPTION
## Summary

- Rewrite `codegen_module` so each generated operation dispatches on its effective security requirement (`op.security ?? doc.security ?? []`) instead of hard-coding `Authorization: Bearer ${client.token}` everywhere.
- Emit one `_headers_<scheme>(client)` helper per security scheme *actually referenced* by some operation, plus `_no_auth_headers(client)` for `security: []`. Support: bearer, basic, apiKey (header / query / cookie), oauth2, openIdConnect. mutualTLS lands a no-op helper + NOTE comment so emission never blocks.
- `new_client` is synthesized from the used-scheme set, only exposing the fields those helpers read (`token`, `basic_user` + `basic_password`, `api_keys`). All fields are optional — no credentials are required unless a caller reaches an operation that needs them.
- apiKey-in-query schemes additionally emit `_query_<scheme>_dict(client)` whose result is spread into each using op's query-bindings dict.
- Multi-requirement security picks the first requirement and prepends a `// TODO: security alternatives also accepted: ...` comment above the generated function.

Closes #4.

## Notion fixture verification

Regenerating the bundled Notion SDK now produces (abridged):

```harn
pub fn new_client(
  base_url: string = "https://api.notion.com",
  token: string = "",
  basic_user: string = "",
  basic_password: string = "",
  extra_headers: dict = {"Notion-Version": "2025-09-03"},
) -> dict { ... }

fn _headers_bearerauth(client: dict) -> dict { ... }   // used by default ops
fn _headers_basicauth(client: dict) -> dict { ... }    // used by /v1/oauth/*

pub fn retrieve_a_block(client, block_id) -> dict {
  let resp = http_get(url, {headers: _headers_bearerauth(client)})
  ...
}

pub fn create_a_token(client, body) -> dict {
  let resp = http_post(url, body_str, {headers: _headers_basicauth(client)})
  ...
}
```

Note on the acceptance bullet about `create_a_token` / `revoke_token` / `introspect_token`: the pinned Notion fixture declares `security: [{basicAuth: []}]` on those operations, so they now emit `_headers_basicauth` rather than the bearer helper. They no longer send a Bearer Authorization header (the bug the issue flagged); they send Basic per spec.

## Test plan

Covered by the new `tests/security_smoke.harn` (nine synthetic-spec scenarios, each round-tripped through `harn check`):

- [x] `harn check src/lib.harn`
- [x] `harn lint src/lib.harn`
- [x] `harn fmt --check src/lib.harn`
- [x] `harn run tests/parse_smoke.harn`
- [x] `harn run tests/walk_smoke.harn`
- [x] `harn run tests/codegen_smoke.harn` (Notion fixture — still green)
- [x] `harn run tests/security_smoke.harn` (A=bearer, B=explicit `security: []` override, C=basic, D=apiKey header, E=apiKey query, F=apiKey cookie, G=oauth2, H=mixed bearer+basic with per-op override mirroring Notion, I=mutualTLS fallback)

## Follow-ups

- Upstream `http_mock_calls()` currently records `method` / `url` / `body` but not request headers; the smoke tests consequently assert on the generated *source text* plus per-helper shape rather than observed outbound headers. Worth a separate issue against harn-core to capture headers in mock call records so downstream SDK tests can assert on the wire shape directly.
- Full OAuth2 flows (authorization-code / device / PKCE) and mutualTLS client-certificate plumbing remain out of scope for v0 as stipulated in #4.