### PR TITLE
[codex] Polish M4 docs and template coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Once Harn package management v0
 harn add github.com/burin-labs/harn-openapi@v0.1.0
 ```
 
-Until then, depend on this repo via a path import in your `harn.toml`:
+Until then, depend on a local checkout of this repo through `harn.toml`:
 
 ```toml
 [dependencies]
@@ -27,14 +27,23 @@ harn-openapi = { path = "../harn-openapi" }
 
 ## Usage
 
+With either the future package install or the current `harn.toml` path
+dependency, import the named functions you use:
+
 ```harn
-import "harn-openapi"
+import {
+  parse,
+  operations,
+  webhook_operations,
+  component_path_items,
+  codegen_module,
+} from "harn-openapi"
 
 let raw = read_file("./notion.openapi.json")
-let doc: OpenApiDoc = parse(raw)
+let doc = parse(raw)
 
 // Walk operations
-let ops: list<Operation> = operations(doc)
+let ops = operations(doc)
 for op in ops {
   println("${op.method} ${op.path} -> ${op.operation_id}")
 }
@@ -45,7 +54,7 @@ for wop in webhook_operations(doc) {
 }
 
 // Passthrough accessor for the 3.1-new components.pathItems map
-let shared_path_items: dict<string, RefOr<PathItem>> = component_path_items(doc)
+let shared_path_items = component_path_items(doc)
 
 // Generate Harn SDK source from the parsed document
 let src = codegen_module(doc, {
@@ -53,6 +62,13 @@ let src = codegen_module(doc, {
   client_name: "Client",
 })
 write_file("./src/lib.harn", src)
+```
+
+When running examples or tests directly from this repository before package
+management ships, use the source path instead:
+
+```harn
+import { parse } from "../src/lib"
 ```
 
 ### Exported surface
@@ -118,7 +134,7 @@ new_client(
 
 When an operation declares multiple security requirement alternatives
 (`security: [{a: []}, {b: []}]`), v0 picks the first and leaves a
-`TODO` comment above the generated function listing the alternatives so
+`NOTE` comment above the generated function listing the alternatives so
 a human can retarget manually.
 
 Out of scope for v0: full OAuth2 flows (authorization-code, device,

--- a/SESSION_PROMPT.md
+++ b/SESSION_PROMPT.md
@@ -59,7 +59,7 @@ Pure-Harn modules that:
   normalized doc structure: `{ openapi, info, servers, paths, components,
   security_schemes, tags }`. Deliberately fail fast on `openapi != "3.1.x"`.
 - Acceptance: `tests/parse_smoke.harn` reads the Notion fixture, parses it,
-  asserts there are >100 operations and the title contains "Notion", and
+  asserts there are >40 operations and the title contains "Notion", and
   exits 0.
 
 ### M2 — Walking helpers

--- a/src/lib.harn
+++ b/src/lib.harn
@@ -894,10 +894,10 @@ fn _build_op_model(op, taken_names, choice, schemes, ret) {
   }
   let doc_comment = "/** " + _escape_comment(safe_summary) + " */"
   // If the op had multiple security requirement alternatives, preserve the
-  // discarded names in a TODO comment so a human can retarget manually.
+  // discarded names in a note so a human can retarget manually.
   let alts = choice.alternatives
   let security_note = if type_of(alts) == "list" && len(alts) > 0 {
-    "TODO: security alternatives also accepted: " + join(alts, ", ")
+    "NOTE: security alternatives also accepted: " + join(alts, ", ")
   } else {
     ""
   }

--- a/tests/render_string_smoke.harn
+++ b/tests/render_string_smoke.harn
@@ -1,0 +1,44 @@
+// render_string_smoke — direct coverage for the inline template engine
+// used by codegen_module. codegen_smoke exercises it indirectly; this
+// keeps the public helper covered on its own.
+
+import { render_string } from "../src/lib"
+
+pipeline default() {
+  let template = """
+Hello {{ user.name }}
+{{ if show }}shown{{ else }}hidden{{ end }}
+{{ for item in items }}[{{ item.label }}={{ item.value }}]{{ end }}
+{{ if missing }}bad{{ else if fallback }}fallback{{ else }}none{{ end }}
+"""
+  let out = render_string(
+    template,
+    {
+    user: {name: "Ada"},
+    show: true,
+    fallback: "yes",
+    items: [
+      {label: "alpha", value: 1},
+      {label: "beta", value: 2},
+    ],
+  },
+  )
+
+  assert(contains(out, "Hello Ada"), "dotted lookup should render nested fields")
+  assert(contains(out, "shown"), "truthy if branch should render")
+  assert(!contains(out, "hidden"), "else branch should not render after truthy if")
+  assert(
+    contains(out, "[alpha=1][beta=2]"),
+    "for loop should render every list item in order",
+  )
+  assert(contains(out, "fallback"), "else-if branch should render when first condition is false")
+  assert(!contains(out, "bad"), "falsey first branch should not render")
+
+  let empty_loop = render_string("{{ for item in items }}x{{ end }}", {items: []})
+  assert(empty_loop == "", "empty loops should render nothing")
+
+  let false_branch = render_string("{{ if zero }}bad{{ else }}ok{{ end }}", {zero: 0})
+  assert(false_branch == "ok", "numeric zero should be falsey")
+
+  println("render_string_smoke: ok")
+}

--- a/tests/security_smoke.harn
+++ b/tests/security_smoke.harn
@@ -281,5 +281,26 @@ pipeline default() {
   assert_contains(src_i, "return _no_auth_headers(client)", "I/falls-back-to-no-auth")
   check_generates(src_i, "I")
 
+  // ------------------------------------------------------------------
+  // Scenario J: multiple security alternatives are preserved as a NOTE,
+  // not a TODO, so generated code can be committed without open TODOs.
+  // ------------------------------------------------------------------
+  let doc_j = build_doc(
+    {
+      bearerAuth: {type: "http", scheme: "bearer"},
+      basicAuth: {type: "http", scheme: "basic"},
+    },
+    [{bearerAuth: []}, {basicAuth: []}],
+    [{operation_id: "either-auth", method: "get", path: "/either"}],
+  )
+  let src_j = codegen_module(parse(doc_j), {module_name: "j", client_name: "J"})
+  assert_contains(
+    src_j,
+    "NOTE: security alternatives also accepted: basicAuth",
+    "J/security-alternative-note",
+  )
+  assert_not_contains(src_j, "TODO", "J/generated-source-has-no-todos")
+  check_generates(src_j, "J")
+
   println("security_smoke: ok")
 }


### PR DESCRIPTION
## Summary

Closes #8.

- Reconcile README usage with the current import surface and path-dependency workflow.
- Correct the SESSION_PROMPT M1 operation-count acceptance from >100 to >40 for the pinned Notion fixture.
- Add direct smoke coverage for `render_string`.
- Replace generated security-alternative TODO wording with NOTE and assert generated code has no TODOs in that path.

## Validation

- `cargo run --quiet --bin harn -- check /Users/ksinder/.codex/worktrees/a518/harn-openapi/src/lib.harn`
- `cargo run --quiet --bin harn -- lint /Users/ksinder/.codex/worktrees/a518/harn-openapi/src/lib.harn`
- `cargo run --quiet --bin harn -- fmt --check /Users/ksinder/.codex/worktrees/a518/harn-openapi/src/lib.harn`
- `for t in /Users/ksinder/.codex/worktrees/a518/harn-openapi/tests/*.harn; do cargo run --quiet --bin harn -- run "$t" || exit 1; done`
- `cargo run --quiet --bin harn -- run /Users/ksinder/.codex/worktrees/a518/harn-openapi/scripts/regen_demo.harn`