### PR TITLE
[codex] Preserve $ref siblings during schema resolution

### DIFF
--- a/src/lib.harn
+++ b/src/lib.harn
@@ -334,7 +334,8 @@ fn _resolve_ref(doc, node) {
     return node
   }
   let target = _lookup_ref(doc, ref)
-  return _merge_schema(target, node)
+  let siblings = _omit_key(node, "$ref")
+  return _merge_shallow(target, siblings)
 }
 
 fn _lookup_ref(doc, ref) {
@@ -381,6 +382,20 @@ fn _merge_schema(base, overlay) {
     } else {
       merged = {...merged, [k]: v}
     }
+  }
+  return merged
+}
+
+fn _merge_shallow(base, overlay) {
+  if type_of(base) != "dict" {
+    return overlay
+  }
+  if type_of(overlay) != "dict" {
+    return base
+  }
+  var merged = base
+  for entry in overlay {
+    merged = {...merged, [entry.key]: entry.value}
   }
   return merged
 }

--- a/tests/ref_siblings_smoke.harn
+++ b/tests/ref_siblings_smoke.harn
@@ -1,0 +1,63 @@
+// ref_siblings_smoke - issue #6 acceptance: JSON Schema 2020-12
+// allows `$ref` siblings, and caller-side sibling keywords must survive
+// resolution with caller-side values taking precedence.
+import { parse, schema } from "../src/lib"
+
+let _TINY_DOC = """
+  {
+    "openapi": "3.1.0",
+    "info": { "title": "Ref Siblings API", "version": "1.0.0" },
+    "paths": {},
+    "components": {
+      "schemas": {
+        "BaseObject": {
+          "title": "Base title",
+          "description": "Base description",
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": { "type": "string" }
+          }
+        },
+        "ComposedObject": {
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/BaseObject",
+              "title": "Branch title"
+            },
+            {
+              "type": "object",
+              "required": ["name"],
+              "properties": {
+                "name": { "type": "string" }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+  """
+
+pipeline default() {
+  let doc = parse(_TINY_DOC)
+  let bare = schema(doc, {["$ref"]: "#/components/schemas/BaseObject"})
+  assert(bare.get("$ref") == nil, "bare $ref should resolve to the target schema")
+  assert(bare.title == "Base title", "bare $ref should preserve target title")
+  assert(bare.description == "Base description", "bare $ref should preserve target description")
+  assert(bare.properties.get("id") != nil, "bare $ref should preserve target properties")
+  let described = schema(doc, {["$ref"]: "#/components/schemas/BaseObject", description: "Caller description"})
+  assert(described.get("$ref") == nil, "resolved schema should not keep the control $ref keyword")
+  assert(
+    described.description == "Caller description",
+    "$ref sibling description should override the target description",
+  )
+  assert(described.title == "Base title", "unrelated target keywords should remain")
+  let composed = schema(doc, {["$ref"]: "#/components/schemas/ComposedObject"})
+  assert(composed.title == "Branch title", "$ref sibling title on allOf branch should survive merge")
+  assert(composed.properties.get("id") != nil, "allOf merge should keep referenced branch properties")
+  assert(composed.properties.get("name") != nil, "allOf merge should keep inline branch properties")
+  assert(composed.required.contains("id"), "allOf merge should keep referenced branch requirements")
+  assert(composed.required.contains("name"), "allOf merge should keep inline branch requirements")
+  println("ref_siblings_smoke: ok")
+}

--- a/tests/types_smoke.harn
+++ b/tests/types_smoke.harn
@@ -14,8 +14,8 @@ pipeline default() {
   let ref_with_sibling = {["$ref"]: "#/components/schemas/annotationResponse", description: "sibling description"}
   require is_reference(ref_with_sibling), "is_reference should detect $ref dicts"
   let resolved: Schema = schema(doc, ref_with_sibling)
-  require resolved.get("$ref") != nil, "schema() should preserve the original $ref sibling"
-  require resolved.description == "sibling description", "schema() should preserve $ref siblings"
+  require resolved.get("$ref") == nil, "schema() should resolve the control $ref keyword away"
+  require resolved.description == "sibling description", "schema() should preserve non-$ref siblings"
   let enum_schema: Schema = {type: "string", enum: ["a", "b"]}
   let values = enum_values(enum_schema)
   require values != nil && len(values) == 2, "enum_values should preserve typed enum lists"


### PR DESCRIPTION
## Summary

- Resolve schema `$ref` values by overlaying non-`$ref` sibling keywords onto the referenced target, with caller-side siblings taking precedence.
- Add a focused `ref_siblings_smoke` fixture covering bare refs, description overrides, and `$ref` siblings inside an `allOf` branch.
- Update the typed smoke assertion to expect the control `$ref` keyword to be resolved away while preserving non-`$ref` siblings.

Closes #6.

## Validation

- `CARGO_TARGET_DIR=/tmp/harn-openapi-issue6-target cargo run --quiet --bin harn -- check /Users/ksinder/.codex/worktrees/ab59/harn-openapi/src/lib.harn`
- `CARGO_TARGET_DIR=/tmp/harn-openapi-issue6-target cargo run --quiet --bin harn -- lint /Users/ksinder/.codex/worktrees/ab59/harn-openapi/src/lib.harn`
- `CARGO_TARGET_DIR=/tmp/harn-openapi-issue6-target cargo run --quiet --bin harn -- fmt --check /Users/ksinder/.codex/worktrees/ab59/harn-openapi/src/lib.harn /Users/ksinder/.codex/worktrees/ab59/harn-openapi/tests/ref_siblings_smoke.harn /Users/ksinder/.codex/worktrees/ab59/harn-openapi/tests/types_smoke.harn`
- `for t in /Users/ksinder/.codex/worktrees/ab59/harn-openapi/tests/*.harn; do CARGO_TARGET_DIR=/tmp/harn-openapi-issue6-target cargo run --quiet --bin harn -- run "$t"; done`