### PR TITLE
[codex] Add fixture refresh workflow

### DIFF
--- a/.github/workflows/fixture-staleness.yml
+++ b/.github/workflows/fixture-staleness.yml
@@ -1,0 +1,28 @@
+name: Fixture staleness
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  check-fixture-staleness:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out harn-openapi
+        uses: actions/checkout@v4
+        with:
+          path: harn-openapi
+
+      - name: Check out harn
+        uses: actions/checkout@v4
+        with:
+          repository: burin-labs/harn
+          path: harn
+
+      - name: Check fixture staleness
+        run: |
+          cd harn
+          cargo run --quiet --bin harn -- run ../harn-openapi/scripts/check_fixture_staleness.harn

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,25 @@ cargo run --quiet --bin harn -- lint /Users/ksinder/projects/harn-openapi/src/li
 cargo run --quiet --bin harn -- fmt --check /Users/ksinder/projects/harn-openapi/src/lib.harn
 ```
 
+## Fixture refresh workflow
+
+The Notion OpenAPI fixture is pinned for deterministic tests. Refresh it only
+when intentionally updating the snapshot:
+
+```sh
+cp tests/fixtures/notion.openapi.json /tmp/notion.openapi.old.json
+cd /Users/ksinder/projects/harn
+cargo run --quiet --bin harn -- run /Users/ksinder/projects/harn-openapi/scripts/refresh_fixtures.harn
+cargo run --quiet --bin harn -- run /Users/ksinder/projects/harn-openapi/scripts/fixture_diff.harn -- \
+  /tmp/notion.openapi.old.json \
+  /Users/ksinder/projects/harn-openapi/tests/fixtures/notion.openapi.json
+```
+
+Commit the updated JSON and `tests/fixtures/notion.openapi.json.meta.toml`
+together. CI runs `scripts/check_fixture_staleness.harn`: under 90 days is OK,
+90–180 days prints a warning, and over 180 days fails non-`main` branches while
+warning on `main`.
+
 ## Upstream conventions
 
 For general Harn coding conventions and the broader project layout, defer to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,25 @@ cargo run --quiet --bin harn -- lint /Users/ksinder/projects/harn-openapi/src/li
 cargo run --quiet --bin harn -- fmt --check /Users/ksinder/projects/harn-openapi/src/lib.harn
 ```
 
+## Fixture refresh workflow
+
+The Notion OpenAPI fixture is pinned for deterministic tests. Refresh it only
+when intentionally updating the snapshot:
+
+```sh
+cp tests/fixtures/notion.openapi.json /tmp/notion.openapi.old.json
+cd /Users/ksinder/projects/harn
+cargo run --quiet --bin harn -- run /Users/ksinder/projects/harn-openapi/scripts/refresh_fixtures.harn
+cargo run --quiet --bin harn -- run /Users/ksinder/projects/harn-openapi/scripts/fixture_diff.harn -- \
+  /tmp/notion.openapi.old.json \
+  /Users/ksinder/projects/harn-openapi/tests/fixtures/notion.openapi.json
+```
+
+Commit the updated JSON and `tests/fixtures/notion.openapi.json.meta.toml`
+together. CI runs `scripts/check_fixture_staleness.harn`: under 90 days is OK,
+90–180 days prints a warning, and over 180 days fails non-`main` branches while
+warning on `main`.
+
 ## Upstream conventions
 
 For general Harn coding conventions and the broader project layout, defer to

--- a/README.md
+++ b/README.md
@@ -133,6 +133,28 @@ The upstream Harn language and runtime live at
 [burin-labs/harn](https://github.com/burin-labs/harn). For local development,
 clone it next to this repo at `../harn`.
 
+### Fixture refresh workflow
+
+The Notion OpenAPI fixture is intentionally pinned. To refresh it manually,
+save the current fixture, run the refresh script, then review the diff report:
+
+```sh
+cp tests/fixtures/notion.openapi.json /tmp/notion.openapi.old.json
+cd ../harn
+cargo run --quiet --bin harn -- run ../harn-openapi/scripts/refresh_fixtures.harn
+cargo run --quiet --bin harn -- run ../harn-openapi/scripts/fixture_diff.harn -- \
+  /tmp/notion.openapi.old.json \
+  ../harn-openapi/tests/fixtures/notion.openapi.json
+```
+
+`scripts/refresh_fixtures.harn` writes both
+`tests/fixtures/notion.openapi.json` and
+`tests/fixtures/notion.openapi.json.meta.toml`, including the upstream URL,
+capture timestamp, byte size, and SHA-256. CI runs
+`scripts/check_fixture_staleness.harn`; it is quiet under 90 days old, warns
+between 90 and 180 days, and fails non-`main` branches once the fixture is over
+180 days old.
+
 ## License
 
 Dual-licensed under MIT and Apache-2.0. Choose whichever you prefer.

--- a/scripts/check_fixture_staleness.harn
+++ b/scripts/check_fixture_staleness.harn
@@ -1,0 +1,77 @@
+// Warn or fail when the pinned Notion fixture metadata is stale.
+//
+// Default target:
+//   tests/fixtures/notion.openapi.json.meta.toml
+//
+// Optional argv[0] overrides the metadata path for tests or one-off checks.
+let _DEFAULT_META_REL_PATH = "tests/fixtures/notion.openapi.json.meta.toml"
+
+let _WARN_AFTER_DAYS = 90
+
+let _FAIL_AFTER_DAYS = 180
+
+fn _repo_root() -> string {
+  return source_dir() + "/.."
+}
+
+fn _default_meta_path() -> string {
+  return _repo_root() + "/" + _DEFAULT_META_REL_PATH
+}
+
+fn _current_branch() -> string {
+  let github_ref = env("GITHUB_REF_NAME")
+  if github_ref != nil && github_ref != "" {
+    return github_ref
+  }
+  let result = shell_at(_repo_root(), "git branch --show-current")
+  if result.success {
+    return result.stdout.trim()
+  }
+  return ""
+}
+
+fn _fixture_age_days(captured_at: string) -> int {
+  let captured_ts = date_parse(captured_at)
+  let now_ts = date_now().timestamp
+  return floor((now_ts - captured_ts) / 86400.0)
+}
+
+pipeline default() {
+  let meta_path = if len(argv) > 0 {
+    argv[0]
+  } else {
+    _default_meta_path()
+  }
+  if !file_exists(meta_path) {
+    throw "check_fixture_staleness: missing metadata file " + meta_path
+  }
+  let meta = toml_parse(read_file(meta_path))
+  let captured_at = meta.get("captured_at")
+  if captured_at == nil || captured_at == "" {
+    throw "check_fixture_staleness: metadata missing captured_at"
+  }
+  let age_days = _fixture_age_days(captured_at)
+  let upstream_url = meta.get("upstream_url") ?? "unknown upstream"
+  let branch = _current_branch()
+  println("fixture captured_at: ${captured_at}")
+  println("fixture upstream: ${upstream_url}")
+  println("fixture age: ${age_days} days")
+  if age_days < _WARN_AFTER_DAYS {
+    println("fixture staleness: ok")
+    return
+  }
+  if age_days < _FAIL_AFTER_DAYS {
+    println(
+      "::warning title=Notion OpenAPI fixture stale::Pinned fixture is ${age_days} days old; run scripts/refresh_fixtures.harn and review scripts/fixture_diff.harn output.",
+    )
+    return
+  }
+  let message = "Pinned Notion OpenAPI fixture is " + to_string(age_days)
+    + " days old; refresh it or file a periodic refresh issue."
+  if branch == "main" {
+    println("::warning title=Notion OpenAPI fixture expired::${message}")
+    println("fixture staleness: expired on main, warning only")
+    return
+  }
+  throw "check_fixture_staleness: " + message
+}

--- a/scripts/fixture_diff.harn
+++ b/scripts/fixture_diff.harn
@@ -1,0 +1,131 @@
+// Print a structured diff between two OpenAPI fixture captures.
+//
+// Usage:
+//   cargo run --quiet --bin harn -- run scripts/fixture_diff.harn -- old.json new.json
+import { operations, parse, schema } from "../src/lib"
+
+fn _sorted_keys(d) {
+  let ks = d.keys()
+  ks.sort()
+  return ks
+}
+
+fn _operation_key(op) -> string {
+  return op.method.upper() + " " + op.path
+}
+
+fn _operation_label(op) -> string {
+  return _operation_key(op) + " (" + op.operation_id + ")"
+}
+
+fn _operation_index(doc) -> dict {
+  var out = {}
+  for op in operations(doc) {
+    out = {...out, [_operation_key(op)]: op}
+  }
+  return out
+}
+
+fn _schema_names(doc) -> list<string> {
+  let schemas = (doc.components ?? {}).get("schemas") ?? {}
+  return _sorted_keys(schemas)
+}
+
+fn _schema_fields(doc, name: string) -> list<string> {
+  let schemas = (doc.components ?? {}).get("schemas") ?? {}
+  let raw = schemas.get(name)
+  if raw == nil {
+    return []
+  }
+  let resolved = schema(doc, raw)
+  let props = resolved.get("properties") ?? {}
+  return _sorted_keys(props)
+}
+
+fn _diff_list(old_items: list<string>, new_items: list<string>) -> dict {
+  var added = []
+  var removed = []
+  for item in new_items {
+    if !old_items.contains(item) {
+      added = added + [item]
+    }
+  }
+  for item in old_items {
+    if !new_items.contains(item) {
+      removed = removed + [item]
+    }
+  }
+  return {added: added, removed: removed}
+}
+
+fn _print_operation_section(title: string, keys: list<string>, index: dict) {
+  println(title + ":")
+  if len(keys) == 0 {
+    println("  (none)")
+    return
+  }
+  for key in keys {
+    println("  " + _operation_label(index[key]))
+  }
+}
+
+fn _print_schema_name_section(title: string, names: list<string>) {
+  println(title + ":")
+  if len(names) == 0 {
+    println("  (none)")
+    return
+  }
+  for name in names {
+    println("  " + name)
+  }
+}
+
+fn _print_changed_schemas(old_doc, new_doc, shared_names: list<string>) {
+  println("changed schemas:")
+  var count = 0
+  for name in shared_names {
+    let old_fields = _schema_fields(old_doc, name)
+    let new_fields = _schema_fields(new_doc, name)
+    let diff = _diff_list(old_fields, new_fields)
+    if len(diff.added) > 0 || len(diff.removed) > 0 {
+      count = count + 1
+      println(
+        "  " + name + " (+" + to_string(len(diff.added)) + " fields, -"
+        + to_string(len(diff.removed))
+        + " fields)",
+      )
+      if len(diff.added) > 0 {
+        println("    added: " + join(diff.added, ", "))
+      }
+      if len(diff.removed) > 0 {
+        println("    removed: " + join(diff.removed, ", "))
+      }
+    }
+  }
+  if count == 0 {
+    println("  (none)")
+  }
+}
+
+pipeline default() {
+  if len(argv) != 2 {
+    throw "usage: scripts/fixture_diff.harn <old.json> <new.json>"
+  }
+  let old_doc = parse(read_file(argv[0]))
+  let new_doc = parse(read_file(argv[1]))
+  let old_ops = _operation_index(old_doc)
+  let new_ops = _operation_index(new_doc)
+  let op_diff = _diff_list(_sorted_keys(old_ops), _sorted_keys(new_ops))
+  _print_operation_section("added operations", op_diff.added, new_ops)
+  _print_operation_section("removed operations", op_diff.removed, old_ops)
+  let schema_diff = _diff_list(_schema_names(old_doc), _schema_names(new_doc))
+  _print_schema_name_section("added schemas", schema_diff.added)
+  _print_schema_name_section("removed schemas", schema_diff.removed)
+  var shared_schemas = []
+  for name in _schema_names(new_doc) {
+    if _schema_names(old_doc).contains(name) {
+      shared_schemas = shared_schemas + [name]
+    }
+  }
+  _print_changed_schemas(old_doc, new_doc, shared_schemas)
+}

--- a/scripts/refresh_fixtures.harn
+++ b/scripts/refresh_fixtures.harn
@@ -1,0 +1,79 @@
+// Refresh the pinned Notion OpenAPI fixture and write capture metadata.
+//
+// Run from the upstream Harn checkout:
+//   cargo run --quiet --bin harn -- run \
+//     /path/to/harn-openapi/scripts/refresh_fixtures.harn
+let _NOTION_OPENAPI_URL = "https://developers.notion.com/openapi.json"
+
+let _FIXTURE_REL_PATH = "tests/fixtures/notion.openapi.json"
+
+let _META_REL_PATH = "tests/fixtures/notion.openapi.json.meta.toml"
+
+fn _repo_root() -> string {
+  return source_dir() + "/.."
+}
+
+fn _fixture_path() -> string {
+  return _repo_root() + "/" + _FIXTURE_REL_PATH
+}
+
+fn _meta_path() -> string {
+  return _repo_root() + "/" + _META_REL_PATH
+}
+
+fn _toml_quote(value: string) -> string {
+  return "\"" + replace(replace(value, "\\", "\\\\"), "\"", "\\\"") + "\""
+}
+
+fn _render_meta(captured_at: string, hash: string, byte_size: int) -> string {
+  return "upstream_url = " + _toml_quote(_NOTION_OPENAPI_URL) + "\n"
+    + "captured_at = "
+    + _toml_quote(captured_at)
+    + "\n"
+    + "captured_by = \"scripts/refresh_fixtures.harn\"\n"
+    + "sha256 = "
+    + _toml_quote(hash)
+    + "\n"
+    + "byte_size = "
+    + to_string(byte_size)
+    + "\n"
+}
+
+pipeline default() {
+  let fixture_path = _fixture_path()
+  let meta_path = _meta_path()
+  let old_size = if file_exists(fixture_path) {
+    stat(fixture_path).size
+  } else {
+    0
+  }
+  let old_hash = if file_exists(fixture_path) {
+    sha256(read_file(fixture_path))
+  } else {
+    ""
+  }
+  println("fetching ${_NOTION_OPENAPI_URL}")
+  let response = http_get(
+    _NOTION_OPENAPI_URL,
+    {timeout_ms: 60000, headers: {["User-Agent"]: "harn-openapi-fixture-refresh"}},
+  )
+  if !response.ok {
+    throw "refresh_fixtures: upstream returned HTTP " + to_string(response.status)
+  }
+  let captured_at = date_iso()
+  let body = response.body
+  let new_hash = sha256(body)
+  write_file(fixture_path, body)
+  let new_size = stat(fixture_path).size
+  write_file(meta_path, _render_meta(captured_at, new_hash, new_size))
+  let delta = new_size - old_size
+  println("wrote ${fixture_path}")
+  println("wrote ${meta_path}")
+  println("captured_at: ${captured_at}")
+  println("sha256: ${new_hash}")
+  println("bytes: ${old_size} -> ${new_size} (delta ${delta})")
+  if old_hash != "" && old_hash != new_hash {
+    println("previous sha256: ${old_hash}")
+  }
+  println("refresh_fixtures: ok")
+}

--- a/scripts/regen_demo.harn
+++ b/scripts/regen_demo.harn
@@ -5,25 +5,26 @@
 //
 //   cd /Users/ksinder/projects/harn
 //   cargo run --quiet --bin harn -- run \
-//     /Users/ksinder/projects/harn-openapi/scripts/regen_demo.harn
-
-import { parse, operations, codegen_module } from "../src/lib"
+//     /path/to/harn-openapi/scripts/regen_demo.harn
+import { codegen_module, operations, parse } from "../src/lib"
 
 pipeline default() {
-  let fixture = "/Users/ksinder/projects/harn-openapi/tests/fixtures/notion.openapi.json"
+  let fixture = source_dir() + "/../tests/fixtures/notion.openapi.json"
   let raw = read_file(fixture)
   let doc = parse(raw)
   let ops = operations(doc)
   println("parsed ${doc.info.title} (OpenAPI ${doc.openapi})")
   println("  operations: ${len(ops)}")
   println("  schemas:    ${len(doc.components.schemas)}")
-
-  let src = codegen_module(doc, {
+  let src = codegen_module(
+    doc,
+    {
     module_name: "notion",
     client_name: "NotionClient",
     default_base_url: "https://api.notion.com",
-    header_overrides: {"Notion-Version": "2025-09-03"},
-  })
+    header_overrides: {["Notion-Version"]: "2025-09-03"},
+  },
+  )
   let out = "/tmp/harn-openapi-regen-demo.harn"
   write_file(out, src)
   println("  wrote:      ${out} (${len(src)} bytes)")

--- a/tests/codegen_smoke.harn
+++ b/tests/codegen_smoke.harn
@@ -1,27 +1,27 @@
 // codegen_smoke — M3 acceptance: generate a Harn SDK module from the
 // pinned Notion fixture, write it out, and shell out to `harn check`
 // to assert the emitted source parses cleanly.
-
-import { parse, codegen_module } from "../src/lib"
+import { codegen_module, parse } from "../src/lib"
 
 pipeline default() {
-  let raw = read_file("/Users/ksinder/projects/harn-openapi/tests/fixtures/notion.openapi.json")
+  let raw = read_file(source_dir() + "/fixtures/notion.openapi.json")
   let doc = parse(raw)
-
-  let src = codegen_module(doc, {
+  let src = codegen_module(
+    doc,
+    {
     module_name: "notion",
     client_name: "NotionClient",
     default_base_url: "https://api.notion.com",
-    header_overrides: {"Notion-Version": "2025-09-03"},
-  })
-
+    header_overrides: {["Notion-Version"]: "2025-09-03"},
+  },
+  )
   let out_path = "/tmp/harn-openapi-codegen-smoke.harn"
   write_file(out_path, src)
   println("wrote generated module: ${out_path} (${len(src)} bytes)")
-
   let harn_root = "/Users/ksinder/projects/harn"
   let cmd = "cd " + harn_root
-    + " && cargo run --quiet --bin harn -- check " + out_path
+    + " && cargo run --quiet --bin harn -- check "
+    + out_path
   let result = shell(cmd)
   if !result.success {
     println("harn check stderr:")

--- a/tests/fixture_workflow_smoke.harn
+++ b/tests/fixture_workflow_smoke.harn
@@ -1,0 +1,106 @@
+/* Smoke coverage for issue #7 fixture refresh support scripts. */
+pipeline default() {
+  let repo_root = source_dir() + "/.."
+  let harn_root = "/Users/ksinder/projects/harn"
+  let unique = to_string(to_int(timestamp())) + "-" + uuid()
+  let old_path = temp_dir() + "/harn-openapi-old-" + unique + ".json"
+  let new_path = temp_dir() + "/harn-openapi-new-" + unique + ".json"
+  let old_doc = """
+    {
+      "openapi": "3.1.0",
+      "info": {"title": "Fixture Diff Smoke", "version": "1.0.0"},
+      "paths": {
+        "/widgets/{id}": {
+          "get": {
+            "operationId": "get-widget",
+            "responses": {"200": {"description": "ok"}}
+          }
+        },
+        "/legacy": {
+          "patch": {
+            "operationId": "patch-legacy",
+            "responses": {"200": {"description": "ok"}}
+          }
+        }
+      },
+      "components": {
+        "schemas": {
+          "Widget": {
+            "type": "object",
+            "properties": {
+              "id": {"type": "string"},
+              "old_name": {"type": "string"}
+            }
+          },
+          "Legacy": {"type": "object", "properties": {"id": {"type": "string"}}}
+        }
+      }
+    }
+    """
+  let new_doc = """
+    {
+      "openapi": "3.1.0",
+      "info": {"title": "Fixture Diff Smoke", "version": "1.0.1"},
+      "paths": {
+        "/widgets/{id}": {
+          "get": {
+            "operationId": "get-widget",
+            "responses": {"200": {"description": "ok"}}
+          }
+        },
+        "/widgets": {
+          "post": {
+            "operationId": "create-widget",
+            "responses": {"201": {"description": "created"}}
+          }
+        }
+      },
+      "components": {
+        "schemas": {
+          "Widget": {
+            "type": "object",
+            "properties": {
+              "id": {"type": "string"},
+              "name": {"type": "string"}
+            }
+          },
+          "NewThing": {"type": "object", "properties": {"id": {"type": "string"}}}
+        }
+      }
+    }
+    """
+  write_file(old_path, old_doc)
+  write_file(new_path, new_doc)
+  let diff_cmd = "cd " + harn_root + " && cargo run --quiet --bin harn -- run "
+    + repo_root
+    + "/scripts/fixture_diff.harn -- "
+    + old_path
+    + " "
+    + new_path
+  let diff = shell(diff_cmd)
+  if !diff.success {
+    println(diff.stderr)
+    println(diff.stdout)
+  }
+  require diff.success, "fixture_diff.harn must run"
+  require contains(diff.stdout, "added operations:"), "diff output must include added operations"
+  require contains(diff.stdout, "POST /widgets (create-widget)"), "diff output must include added op"
+  require contains(diff.stdout, "removed operations:"), "diff output must include removed operations"
+  require contains(diff.stdout, "PATCH /legacy (patch-legacy)"), "diff output must include removed op"
+  require contains(diff.stdout, "added schemas:"), "diff output must include added schemas"
+  require contains(diff.stdout, "NewThing"), "diff output must include added schema"
+  require contains(diff.stdout, "removed schemas:"), "diff output must include removed schemas"
+  require contains(diff.stdout, "Legacy"), "diff output must include removed schema"
+  require contains(diff.stdout, "Widget (+1 fields, -1 fields)"), "diff output must summarize schema field changes"
+  let stale_cmd = "cd " + harn_root + " && cargo run --quiet --bin harn -- run "
+    + repo_root
+    + "/scripts/check_fixture_staleness.harn"
+  let stale = shell(stale_cmd)
+  if !stale.success {
+    println(stale.stderr)
+    println(stale.stdout)
+  }
+  require stale.success, "check_fixture_staleness.harn must pass for committed metadata"
+  require contains(stale.stdout, "fixture staleness: ok"), "fixture should not be stale yet"
+  println("fixture_workflow_smoke: ok")
+}

--- a/tests/fixtures/notion.openapi.json.meta.toml
+++ b/tests/fixtures/notion.openapi.json.meta.toml
@@ -1,0 +1,5 @@
+upstream_url = "https://developers.notion.com/openapi.json"
+captured_at = "2026-04-20T12:08:23Z"
+captured_by = "scripts/refresh_fixtures.harn"
+sha256 = "1acaa25d1e0ceab03e38f1f71deb8b2d63fd83a7d974ce32ed27e1342714af20"
+byte_size = 1019138

--- a/tests/parse_smoke.harn
+++ b/tests/parse_smoke.harn
@@ -1,15 +1,12 @@
 // parse_smoke — M1 acceptance: parse the pinned Notion OpenAPI
 // fixture and assert the doc looks plausible.
 //
-// The fixture was produced with:
-//   curl -fsSL https://developers.notion.com/openapi.json \
-//     > tests/fixtures/notion.openapi.json
+// The fixture is refreshed manually via scripts/refresh_fixtures.harn.
 // Keep it pinned — do not auto-refresh.
-
-import { parse, operations } from "../src/lib"
+import { operations, parse } from "../src/lib"
 
 pipeline default() {
-  let raw = read_file("/Users/ksinder/projects/harn-openapi/tests/fixtures/notion.openapi.json")
+  let raw = read_file(source_dir() + "/fixtures/notion.openapi.json")
   let doc = parse(raw)
   assert(starts_with(doc.openapi, "3.1"), "openapi version must be 3.1.x")
   assert(contains(doc.info.title, "Notion"), "info.title must contain 'Notion'")

--- a/tests/response_types_smoke.harn
+++ b/tests/response_types_smoke.harn
@@ -219,7 +219,7 @@ pipeline default() {
   assert(result.success, "generated module must pass `harn check` (status ${result.status})")
   // --- Acceptance 8: on the Notion fixture, emit >=20 distinct type
   // aliases, and fn signatures reuse them by name. ---
-  let notion_raw = read_file("/Users/ksinder/projects/harn-openapi/tests/fixtures/notion.openapi.json")
+  let notion_raw = read_file(source_dir() + "/fixtures/notion.openapi.json")
   let notion_doc = parse(notion_raw)
   let notion_src = codegen_module(
     notion_doc,

--- a/tests/types_smoke.harn
+++ b/tests/types_smoke.harn
@@ -3,7 +3,7 @@ import "../src/lib"
 
 @test
 pipeline default() {
-  let raw = read_file("/Users/ksinder/projects/harn-openapi/tests/fixtures/notion.openapi.json")
+  let raw = read_file(source_dir() + "/fixtures/notion.openapi.json")
   let doc: OpenApiDoc = parse(raw)
   require is_openapi_doc(doc), "parse(raw) should satisfy the OpenApiDoc guard"
   let ops: list<Operation> = operations(doc)

--- a/tests/walk_smoke.harn
+++ b/tests/walk_smoke.harn
@@ -1,16 +1,13 @@
 // walk_smoke — M2 acceptance: enumerate operations, resolve the
 // databases.query request body schema, print its property names, and
 // exercise enum_values() on a known enum schema.
-
-import { parse, operations, schema, enum_values } from "../src/lib"
+import { enum_values, operations, parse, schema } from "../src/lib"
 
 pipeline default() {
-  let raw = read_file("/Users/ksinder/projects/harn-openapi/tests/fixtures/notion.openapi.json")
+  let raw = read_file(source_dir() + "/fixtures/notion.openapi.json")
   let doc = parse(raw)
-
   let ops = operations(doc)
   println("operation count: ${len(ops)}")
-
   // Locate the query-a-data-source operation. Notion 2025-11 renamed
   // the classic "databases.query" endpoint to the data-sources URL,
   // so we look up the operation_id instead of the path.
@@ -22,7 +19,6 @@ pipeline default() {
   }
   assert(query_op != nil, "could not find post-database-query operation")
   println("query op: ${query_op.method} ${query_op.path}")
-
   let body_schema_raw = query_op.request_body.content["application/json"].schema
   let resolved = schema(doc, body_schema_raw)
   let fields = resolved.properties.keys()
@@ -32,7 +28,6 @@ pipeline default() {
     println("  - ${f}")
   }
   assert(fields.contains("filter"), "expected 'filter' field on query request body")
-
   // Find any schema with an enum and verify enum_values returns a list.
   var enum_name = ""
   var enum_size = 0
@@ -47,9 +42,7 @@ pipeline default() {
   }
   assert(enum_name != "", "expected at least one enum schema in fixture")
   println("enum example '${enum_name}': ${enum_size} values")
-
   // Sanity-check that enum_values on a non-enum schema returns nil.
   assert(enum_values({type: "object"}) == nil, "enum_values on non-enum must return nil")
-
   println("walk_smoke: ok")
 }

--- a/tests/webhook_smoke.harn
+++ b/tests/webhook_smoke.harn
@@ -6,7 +6,7 @@
 import { component_path_items, parse, schema, webhook_operations } from "../src/lib"
 
 pipeline default() {
-  let raw = read_file("/Users/ksinder/projects/harn-openapi/tests/fixtures/notion.openapi.json")
+  let raw = read_file(source_dir() + "/fixtures/notion.openapi.json")
   let doc = parse(raw)
   // parse() must surface the webhooks map.
   assert(type_of(doc.webhooks) == "dict", "doc.webhooks must be a dict")


### PR DESCRIPTION
## Summary

- add a Notion fixture refresh script that writes JSON plus metadata with captured_at, sha256, upstream URL, and byte size
- add staleness checking, fixture diff reporting, and CI coverage for the staleness check
- document the manual refresh workflow and update fixture-using tests/scripts to use source-relative paths

Closes #7.

## Validation

- CARGO_TARGET_DIR=/tmp/harn-target-harn-openapi-issue7 cargo run --quiet --bin harn -- check src/lib.harn
- CARGO_TARGET_DIR=/tmp/harn-target-harn-openapi-issue7 cargo run --quiet --bin harn -- lint src/lib.harn
- CARGO_TARGET_DIR=/tmp/harn-target-harn-openapi-issue7 cargo run --quiet --bin harn -- fmt --check src/lib.harn
- CARGO_TARGET_DIR=/tmp/harn-target-harn-openapi-issue7 cargo run --quiet --bin harn -- run tests/*.harn
- CARGO_TARGET_DIR=/tmp/harn-target-harn-openapi-issue7 cargo run --quiet --bin harn -- run scripts/check_fixture_staleness.harn
- CARGO_TARGET_DIR=/tmp/harn-target-harn-openapi-issue7 cargo run --quiet --bin harn -- run scripts/regen_demo.harn
