### PR TITLE
[codex] Add connector-facing SDK helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ schema walking, security handling, or typed SDK generation independently. This
 repo keeps that shared logic in one pure-Harn package:
 
 - parse OpenAPI 3.1 JSON into normalized Harn records;
-- walk paths, webhooks, components, schemas, enums, and security metadata;
+- walk paths, webhooks, components, schemas, enums, security metadata,
+  pagination patterns, and rate-limit response conventions;
 - generate typed Harn SDK source for downstream provider repos;
 - keep a pinned real-world Notion OpenAPI fixture for deterministic coverage.
 
@@ -35,6 +36,7 @@ pinned Harn CLI from crates.io using `.harn-version`.
 | `tests/*.harn` | Smoke and behavior tests for parsing, walking, codegen, security, response typing, polymorphic request bodies, fixture tooling, and helper scripts. |
 | `tests/fixtures/notion.openapi.json` | Pinned Notion OpenAPI 3.1 snapshot used as the main real-world fixture. |
 | `tests/fixtures/notion.openapi.json.meta.toml` | Capture metadata for the pinned fixture: upstream URL, timestamp, byte size, and SHA-256. |
+| `tests/fixtures/connector_helpers.openapi.json` | Small synthetic OpenAPI fixture covering auth alternatives, pagination, and rate-limit metadata. |
 | `scripts/regen_demo.harn` | End-to-end parse to codegen demo that writes generated SDK source to `/tmp`. |
 | `scripts/refresh_fixtures.harn` | Refreshes the pinned Notion fixture and metadata intentionally. |
 | `scripts/fixture_diff.harn` | Prints a structured operation/schema diff between two fixture captures. |
@@ -69,7 +71,11 @@ import {
   operations,
   webhook_operations,
   component_path_items,
+  auth_helpers,
+  pagination_plans,
+  rate_limit_metadata,
   codegen_module,
+  codegen_harn_toml,
 } from "harn-openapi/default"
 
 let raw = read_file("./notion.openapi.json")
@@ -89,12 +95,24 @@ for wop in webhook_operations(doc) {
 // Passthrough accessor for the 3.1-new components.pathItems map
 let shared_path_items = component_path_items(doc)
 
+// Connector-facing helper metadata
+let auth = auth_helpers(doc)
+let pages = pagination_plans(doc)
+let limits = rate_limit_metadata(doc)
+
 // Generate Harn SDK source from the parsed document
 let src = codegen_module(doc, {
   module_name: "notion",
   client_name: "Client",
 })
 write_file("./src/lib.harn", src)
+write_file(
+  "./harn.toml",
+  codegen_harn_toml({
+    package_name: "notion-sdk-harn",
+    dependencies: {["harn-openapi"]: {path: "../harn-openapi"}},
+  }),
+)
 ```
 
 When running examples or tests directly from this repository checkout, use the
@@ -130,8 +148,20 @@ import { parse } from "../src/lib"
   or `nil` when the schema is not an enum.
 - `is_openapi_doc(value)`, `is_reference(value)`, `is_schema(value)` — small schema guards
   for common dynamic boundaries.
+- `auth_helpers(doc: OpenApiDoc) -> list<AuthHelper>` — classify each declared
+  security scheme into reusable helper metadata, including generated client
+  fields and OAuth scopes where present.
+- `pagination_plans(doc: OpenApiDoc) -> list<PaginationPlan>` — detect simple
+  cursor, page-number, and next-link list patterns from operation query
+  parameters and success-response schemas.
+- `rate_limit_metadata(doc: OpenApiDoc) -> list<RateLimitMetadata>` — surface
+  per-operation 429, `Retry-After`, and `X-RateLimit-*` response header
+  conventions for downstream retry/backoff code.
 - `codegen_module(doc: OpenApiDoc, options: dict) -> string` — emit a typed Harn SDK
-  module source string with per-scheme security dispatch (see below).
+  module source string with per-scheme security dispatch, credential-provider
+  hooks, pagination metadata, and rate-limit metadata (see below).
+- `codegen_harn_toml(options: dict) -> string` — emit a package manifest for a
+  generated SDK repo with `[package]`, `[exports]`, and `[dependencies]`.
 
 ### Security handling in generated clients
 
@@ -148,9 +178,9 @@ all defaulted so callers only supply what their spec actually needs:
 
 | Scheme kind | Client field added |
 |---|---|
-| `http` + `bearer`, `oauth2`, `openIdConnect` | `token: string = ""` |
-| `http` + `basic` | `basic_user: string = ""`, `basic_password: string = ""` |
-| `apiKey` (header / query / cookie) | `api_keys: dict = {}` (keyed by scheme name) |
+| `http` + `bearer`, `oauth2`, `openIdConnect` | `token: string = ""`, `token_provider = nil` |
+| `http` + `basic` | `basic_user: string = ""`, `basic_password: string = ""`, `basic_provider = nil` |
+| `apiKey` (header / query / cookie) | `api_keys: dict = {}`, `api_key_provider = nil` (keyed by scheme name) |
 | `mutualTLS` | (v0: no-op — op falls through to `_no_auth_headers`) |
 
 So a Notion-shaped spec with `bearerAuth` + `basicAuth` yields:
@@ -159,11 +189,19 @@ So a Notion-shaped spec with `bearerAuth` + `basicAuth` yields:
 new_client(
   base_url: string = "https://api.notion.com",
   token: string = "",
+  token_provider = nil,
   basic_user: string = "",
   basic_password: string = "",
+  basic_provider = nil,
   extra_headers: dict = {"Notion-Version": "..."},
 ) -> dict
 ```
+
+For connector packages, prefer provider hooks over static token strings. The
+generated module includes `token_from_secret(secret_id)` and
+`api_key_from_secret(secret_ids)` helpers that call Harn's active
+`secret_get(...)` connector primitive at request time. Callers can also pass
+custom closures for token refresh, OAuth storage, or multi-tenant key lookup.
 
 When an operation declares multiple security requirement alternatives
 (`security: [{a: []}, {b: []}]`), v0 picks the first and leaves a
@@ -172,6 +210,22 @@ a human can retarget manually.
 
 Out of scope for v0: full OAuth2 flows (authorization-code, device,
 PKCE) and `mutualTLS` client-certificate plumbing.
+
+### Pagination and rate-limit helpers
+
+`pagination_plans(doc)` and generated SDKs expose the same lightweight metadata
+for list operations. The detector intentionally recognizes only common
+provider-neutral shapes: cursor params such as `start_cursor` with response
+fields such as `next_cursor`, page params such as `page` / `per_page`, and
+response next-link fields such as `next_url`.
+
+Generated SDKs include `pagination_plans()`, `pagination_plan(operation_id)`,
+`pagination_items(response, plan)`, and `pagination_next(response, plan)`.
+`rate_limit_metadata(doc)` and generated SDKs surface declared `429`,
+`Retry-After`, and `X-RateLimit-*` headers. Generated SDKs also include
+`rate_limit_from_response(resp)` and `is_rate_limited_response(resp)` so
+connectors can implement retries/backoff consistently without hardcoding every
+endpoint class.
 
 ### Polymorphic request bodies
 

--- a/src/lib.harn
+++ b/src/lib.harn
@@ -42,6 +42,18 @@
 //   is_openapi_doc(value) / is_reference(value) / is_schema(value) -> bool
 //       Guard helpers for common dynamic boundaries.
 //
+//   auth_helpers(doc)           -> list<AuthHelper>
+//       Classify reusable auth helper metadata for each declared security
+//       scheme without choosing provider-specific credential policy.
+//
+//   pagination_plans(doc)       -> list<PaginationPlan>
+//       Detect simple cursor, page-number, and next-link list patterns from
+//       operation parameters and success-response schemas.
+//
+//   rate_limit_metadata(doc)    -> list<RateLimitMetadata>
+//       Surface per-operation 429 / Retry-After / X-RateLimit-* response
+//       header conventions for connector retry and backoff code.
+//
 //   codegen_module(doc, options) -> string
 //       Emit a complete typed Harn SDK module source string. Options:
 //       { module_name, client_name, default_base_url?, header_overrides? }.
@@ -51,9 +63,15 @@
 //       least one operation (bearer / basic / apiKey-in-{header,query,
 //       cookie} / oauth2 / openIdConnect). Operations with `security: []`
 //       dispatch through `_no_auth_headers(client)` so they never send
-//       an Authorization header. `new_client`'s parameter set is
-//       restricted to the fields the emitted helpers actually read
-//       (token, basic_user/basic_password, api_keys).
+//       an Authorization header. `new_client`'s parameter set is restricted
+//       to the fields the emitted helpers actually read and also accepts
+//       SecretProvider-friendly hooks (`token_provider`, `api_key_provider`,
+//       `basic_provider`) so generated SDKs do not embed static secrets.
+//
+//   codegen_harn_toml(options) -> string
+//       Emit package metadata for generated SDK repos. Options:
+//       { package_name, version?, description?, default_export?,
+//       types_export?, dependencies? }.
 //
 // See README.md for end-to-end usage; scripts/regen_demo.harn runs a
 // full parse -> codegen -> write loop against the bundled Notion
@@ -148,6 +166,12 @@ type Components = {schemas?: dict<string, Schema>, responses?: dict<string, RefO
 type OpenApiDoc = {openapi: string, info: Info, jsonSchemaDialect?: string, servers?: list<Server>, paths?: dict<string, PathItem>, webhooks?: dict<string, RefOr<PathItem>>, components?: Components, security?: list<SecurityRequirement>, tags?: list<Tag>, externalDocs?: ExternalDocumentation, security_schemes?: dict<string, RefOr<SecurityScheme>>}
 
 type WebhookOperation = {name: string, method: string, path_item: PathItem, operation: Operation, operation_id: string, summary?: string, description?: string, parameters?: list<RefOr<Parameter>>, request_body?: RefOr<RequestBody>, responses?: Responses, security?: list<SecurityRequirement>, tags?: list<string>}
+
+type AuthHelper = {scheme_name: string, kind: string, client_fields: list<string>, location?: string, parameter_name?: string, scopes?: list<string>}
+
+type PaginationPlan = {operation_id: string, method: string, path: string, kind: string, items_field?: string, cursor_param?: string, cursor_response_field?: string, has_more_field?: string, page_param?: string, page_size_param?: string, next_link_field?: string, link_header?: string}
+
+type RateLimitMetadata = {operation_id: string, method: string, path: string, status?: string, retry_after_header?: string, limit_headers: list<string>, remaining_headers: list<string>, reset_headers: list<string>}
 
 type ParseOpenApiDoc = {openapi: string, info: Info, servers?: list, paths?: dict, webhooks?: dict, components?: dict, security_schemes?: dict, security?: list, tags?: list}
 
@@ -455,6 +479,234 @@ pub fn is_schema(value: unknown) -> bool {
   return schema_is(value, {type: "dict"})
 }
 
+/** Classify reusable auth helper metadata for declared security schemes. */
+pub fn auth_helpers(doc: OpenApiDoc) -> list<AuthHelper> {
+  let schemes = doc.get("security_schemes") ?? {}
+  var out = []
+  for entry in schemes {
+    let name = entry.key
+    let def = entry.value
+    let kind = _scheme_kind(def)
+    var helper = {scheme_name: name, kind: kind, client_fields: _client_fields_for_scheme_kind(kind)}
+    if starts_with(kind, "apiKey-") {
+      helper = {...helper, location: def.get("in") ?? "header", parameter_name: def.get("name") ?? name}
+    }
+    if kind == "oauth2" {
+      helper = {...helper, scopes: _oauth_scope_names(def)}
+    }
+    out = out + [helper]
+  }
+  return out
+}
+
+fn _client_fields_for_scheme_kind(kind) {
+  if kind == "bearer" || kind == "oauth2" || kind == "openIdConnect" {
+    return ["token", "token_provider"]
+  }
+  if kind == "basic" {
+    return ["basic_user", "basic_password", "basic_provider"]
+  }
+  if kind == "apiKey-header" || kind == "apiKey-query" || kind == "apiKey-cookie" {
+    return ["api_keys", "api_key_provider"]
+  }
+  return []
+}
+
+fn _oauth_scope_names(def) {
+  let flows = def.get("flows") ?? {}
+  var scopes = []
+  for flow_name in ["implicit", "password", "clientCredentials", "authorizationCode"] {
+    let flow = flows.get(flow_name)
+    if type_of(flow) == "dict" {
+      let flow_scopes = flow.get("scopes") ?? {}
+      for entry in flow_scopes {
+        if !scopes.contains(entry.key) {
+          scopes = scopes + [entry.key]
+        }
+      }
+    }
+  }
+  scopes.sort()
+  return scopes
+}
+
+/** Detect reusable pagination patterns from operation params and responses. */
+pub fn pagination_plans(doc: OpenApiDoc) -> list<PaginationPlan> {
+  var out = []
+  for op in operations(doc) {
+    let plan = _pagination_plan_for_op(doc, op)
+    if plan != nil {
+      out = out + [plan]
+    }
+  }
+  return out
+}
+
+fn _pagination_plan_for_op(doc, op) {
+  let params = op.parameters ?? []
+  let cursor_param = _first_param_named(params, ["start_cursor", "cursor", "after", "page_token", "next_page_token"])
+  let page_param = _first_param_named(params, ["page", "page_number", "page_index", "offset"])
+  let page_size_param = _first_param_named(params, ["page_size", "per_page", "limit", "size"])
+  let picked = _pick_success_response(op)
+  if picked == nil || picked.kind != "json" {
+    return nil
+  }
+  let full = schema(doc, picked.schema)
+  let props = full.get("properties") ?? {}
+  let items_field = _first_present_key(props, ["results", "data", "items", "records", "objects"])
+  let next_cursor = _first_present_key(props, ["next_cursor", "next_page_token", "cursor", "after"])
+  let has_more = _first_present_key(props, ["has_more", "hasMore", "more"])
+  let next_link = _first_present_key(props, ["next", "next_url", "next_link", "nextPageUrl"])
+  let link_header = _success_response_header(op, "Link")
+  if cursor_param != nil && next_cursor != nil {
+    return {
+      operation_id: op.operation_id,
+      method: op.method,
+      path: op.path,
+      kind: "cursor",
+      items_field: items_field,
+      cursor_param: cursor_param,
+      cursor_response_field: next_cursor,
+      has_more_field: has_more,
+      page_size_param: page_size_param,
+    }
+  }
+  if page_param != nil {
+    return {
+      operation_id: op.operation_id,
+      method: op.method,
+      path: op.path,
+      kind: "page",
+      items_field: items_field,
+      page_param: page_param,
+      page_size_param: page_size_param,
+    }
+  }
+  if next_link != nil || link_header != nil {
+    return {
+      operation_id: op.operation_id,
+      method: op.method,
+      path: op.path,
+      kind: "next_link",
+      items_field: items_field,
+      next_link_field: next_link,
+      link_header: link_header,
+    }
+  }
+  return nil
+}
+
+fn _first_param_named(params, names) {
+  for wanted in names {
+    for p in params {
+      if p.get("in") == "query" && p.get("name") == wanted {
+        return wanted
+      }
+    }
+  }
+  return nil
+}
+
+fn _first_present_key(d, names) {
+  if type_of(d) != "dict" {
+    return nil
+  }
+  for name in names {
+    if d.get(name) != nil {
+      return name
+    }
+  }
+  return nil
+}
+
+fn _success_response_header(op, header_name) {
+  for entry in op.responses {
+    if _is_success_code(entry.key) {
+      let headers = entry.value.get("headers") ?? {}
+      let found = _header_name_case_insensitive(headers, header_name)
+      if found != nil {
+        return found
+      }
+    }
+  }
+  return nil
+}
+
+fn _header_name_case_insensitive(headers, wanted) {
+  if type_of(headers) != "dict" {
+    return nil
+  }
+  for entry in headers {
+    if entry.key.lower() == wanted.lower() {
+      return entry.key
+    }
+  }
+  return nil
+}
+
+/** Surface response header conventions used by retry/backoff code. */
+pub fn rate_limit_metadata(doc: OpenApiDoc) -> list<RateLimitMetadata> {
+  var out = []
+  for op in operations(doc) {
+    let meta = _rate_limit_metadata_for_op(op)
+    if meta != nil {
+      out = out + [meta]
+    }
+  }
+  return out
+}
+
+fn _rate_limit_metadata_for_op(op) {
+  var status = nil
+  var retry_after = nil
+  var limit_headers = []
+  var remaining_headers = []
+  var reset_headers = []
+  for response_entry in op.responses {
+    let code = response_entry.key
+    let headers = response_entry.value.get("headers") ?? {}
+    if code == "429" {
+      status = "429"
+    }
+    let retry_header = _header_name_case_insensitive(headers, "Retry-After")
+    if retry_header != nil {
+      retry_after = retry_header
+    }
+    for header_entry in headers {
+      let header = header_entry.key
+      let normalized = header.lower()
+      if contains(normalized, "ratelimit-limit") || contains(normalized, "rate-limit-limit") {
+        if !limit_headers.contains(header) {
+          limit_headers = limit_headers + [header]
+        }
+      } else if contains(normalized, "ratelimit-remaining")
+        || contains(normalized, "rate-limit-remaining") {
+        if !remaining_headers.contains(header) {
+          remaining_headers = remaining_headers + [header]
+        }
+      } else if contains(normalized, "ratelimit-reset") || contains(normalized, "rate-limit-reset") {
+        if !reset_headers.contains(header) {
+          reset_headers = reset_headers + [header]
+        }
+      }
+    }
+  }
+  if status == nil && retry_after == nil && len(limit_headers) == 0 && len(remaining_headers) == 0
+    && len(reset_headers) == 0 {
+    return nil
+  }
+  return {
+    operation_id: op.operation_id,
+    method: op.method,
+    path: op.path,
+    status: status,
+    retry_after_header: retry_after,
+    limit_headers: limit_headers,
+    remaining_headers: remaining_headers,
+    reset_headers: reset_headers,
+  }
+}
+
 // -----------------------------------------------------------------------------
 // Codegen
 // -----------------------------------------------------------------------------
@@ -482,9 +734,148 @@ let _MODULE_TEMPLATE = """
     }
     return hs
   }
+
+  /** Build a token-provider hook backed by the active connector SecretProvider. */
+  pub fn token_from_secret(secret_id: string) {
+    return fn() {
+      let value = secret_get(secret_id)
+      if value == nil {
+        return ""
+      }
+      return to_string(value)
+    }
+  }
+
+  /** Build an api-key-provider hook backed by the active connector SecretProvider. */
+  pub fn api_key_from_secret(secret_ids: dict) {
+    return fn(scheme_name) {
+      let secret_id = secret_ids.get(scheme_name)
+      if secret_id == nil {
+        return ""
+      }
+      let value = secret_get(secret_id)
+      if value == nil {
+        return ""
+      }
+      return to_string(value)
+    }
+  }
+
+  fn _client_token(client: dict) -> string {
+    let provider = client.get("token_provider")
+    if provider != nil {
+      return to_string(provider())
+    }
+    return to_string(client.get("token") ?? "")
+  }
+
+  fn _client_api_key(client: dict, scheme_name: string) -> string {
+    let provider = client.get("api_key_provider")
+    if provider != nil {
+      return to_string(provider(scheme_name))
+    }
+    return to_string((client.get("api_keys") ?? {}).get(scheme_name) ?? "")
+  }
+
+  fn _client_basic(client: dict) -> dict {
+    let provider = client.get("basic_provider")
+    if provider != nil {
+      return provider()
+    }
+    return {user: client.get("basic_user") ?? "", password: client.get("basic_password") ?? ""}
+  }
+
   {{ for helper in auth_helpers }}
   {{ helper.body }}
   {{ end }}
+  /** Pagination plans detected from the OpenAPI operation shapes. */
+  pub fn pagination_plans() -> list {
+    return {{ pagination_plan_literal }}
+  }
+
+  pub fn pagination_plan(operation_id: string) -> dict | nil {
+    for plan in pagination_plans() {
+      if plan.operation_id == operation_id {
+        return plan
+      }
+    }
+    return nil
+  }
+
+  pub fn pagination_items(response: dict, plan: dict) -> list {
+    let field = plan.get("items_field")
+    if field == nil {
+      return []
+    }
+    let value = response.get(field)
+    if type_of(value) == "list" {
+      return value
+    }
+    return []
+  }
+
+  pub fn pagination_next(response: dict, plan: dict) -> dict {
+    let kind = plan.get("kind")
+    if kind == "cursor" {
+      let cursor_field = plan.get("cursor_response_field")
+      let cursor = if cursor_field == nil {
+        nil
+      } else {
+        response.get(cursor_field)
+      }
+      let has_more_field = plan.get("has_more_field")
+      let has_more = if has_more_field == nil {
+        cursor != nil
+      } else {
+        response.get(has_more_field)
+      }
+      return {done: cursor == nil || has_more == false, query: {[plan.cursor_param]: cursor}}
+    }
+    if kind == "page" {
+      return {done: false, query: {}}
+    }
+    if kind == "next_link" {
+      let field = plan.get("next_link_field")
+      let url = if field == nil {
+        nil
+      } else {
+        response.get(field)
+      }
+      return {done: url == nil || url == "", url: url}
+    }
+    return {done: true, query: {}}
+  }
+
+  /** Rate-limit response/header conventions detected from OpenAPI responses. */
+  pub fn rate_limit_metadata() -> list {
+    return {{ rate_limit_metadata_literal }}
+  }
+
+  fn _header_ci(headers: dict, wanted: string) {
+    for entry in headers {
+      if entry.key.lower() == wanted.lower() {
+        return entry.value
+      }
+    }
+    return nil
+  }
+
+  pub fn rate_limit_from_response(resp: dict) -> dict {
+    let headers = resp.get("headers") ?? {}
+    return {
+      status: resp.get("status"),
+      retry_after: _header_ci(headers, "Retry-After"),
+      limit: _header_ci(headers, "X-RateLimit-Limit"),
+      remaining: _header_ci(headers, "X-RateLimit-Remaining"),
+      reset: _header_ci(headers, "X-RateLimit-Reset"),
+    }
+  }
+
+  pub fn is_rate_limited_response(resp: dict) -> bool {
+    let headers = resp.get("headers") ?? {}
+    return resp.get("status") == 429 || _header_ci(headers, "Retry-After") != nil
+  }
+
   fn _interpolate(template: string, bindings: dict) -> string {
     var out = template
     for entry in bindings {
@@ -612,8 +1003,34 @@ pub fn codegen_module(doc: OpenApiDoc, options: dict) -> string {
     auth_helpers: auth_helpers,
     operations: ops,
     response_aliases: alias_entries,
+    pagination_plan_literal: _render_json_parse_expr(pagination_plans(doc)),
+    rate_limit_metadata_literal: _render_json_parse_expr(rate_limit_metadata(doc)),
   }
   return _normalize_generated_source(render_string(_MODULE_TEMPLATE, bindings), module_name)
+}
+
+/** Emit a harn.toml manifest for a generated SDK package. */
+pub fn codegen_harn_toml(options: dict) -> string {
+  let package_name = options.get("package_name") ?? options.get("module_name") ?? "generated-sdk"
+  let version = options.get("version") ?? "0.0.0"
+  let description = options.get("description") ?? "Generated Harn SDK package."
+  let default_export = options.get("default_export") ?? "src/lib.harn"
+  let types_export = options.get("types_export")
+  let dependencies = options.get("dependencies") ?? {}
+  var out = "[package]\n"
+  out = out + "name = \"" + _escape_toml_string(package_name) + "\"\n"
+  out = out + "version = \"" + _escape_toml_string(version) + "\"\n"
+  out = out + "description = \"" + _escape_toml_string(description) + "\"\n\n"
+  out = out + "[exports]\n"
+  out = out + "default = \"" + _escape_toml_string(default_export) + "\"\n"
+  if types_export != nil {
+    out = out + "types = \"" + _escape_toml_string(types_export) + "\"\n"
+  }
+  out = out + "\n[dependencies]\n"
+  for entry in dependencies {
+    out = out + _render_manifest_dependency(entry.key, entry.value)
+  }
+  return out
 }
 
 /**
@@ -685,13 +1102,16 @@ fn _derive_client_fields(used_schemes, schemes) {
   var fields = []
   if want_token {
     fields = fields + [{name: "token", kind: "string", default: "\"\""}]
+    fields = fields + [{name: "token_provider", kind: "dynamic", default: "nil"}]
   }
   if want_basic {
     fields = fields + [{name: "basic_user", kind: "string", default: "\"\""}]
     fields = fields + [{name: "basic_password", kind: "string", default: "\"\""}]
+    fields = fields + [{name: "basic_provider", kind: "dynamic", default: "nil"}]
   }
   if want_api_keys {
     fields = fields + [{name: "api_keys", kind: "dict", default: "{}"}]
+    fields = fields + [{name: "api_key_provider", kind: "dynamic", default: "nil"}]
   }
   return fields
 }
@@ -747,6 +1167,8 @@ fn _render_new_client_decl(fields, default_base_url, header_overrides) {
       parts = parts + [f.name + ": string = " + f.default]
     } else if f.kind == "dict" {
       parts = parts + [f.name + ": dict = " + f.default]
+    } else {
+      parts = parts + [f.name + " = " + f.default]
     }
   }
   parts = parts + ["extra_headers: dict = " + _render_dict_literal(header_overrides)]
@@ -810,7 +1232,7 @@ fn _render_auth_helper(scheme_name, def) {
       + "  var hs = "
       + _render_binding_dict(
       [
-      "Authorization: \"Bearer \" + to_string(client.token)",
+      "Authorization: \"Bearer \" + _client_token(client)",
       _harn_dict_entry("Content-Type", "\"application/json\""),
     ],
     )
@@ -823,7 +1245,8 @@ fn _render_auth_helper(scheme_name, def) {
   }
   if kind == "basic" {
     return "fn " + fn_name + "(client: dict) -> dict {\n"
-      + "  let encoded = base64_encode(to_string(client.basic_user) + \":\" + to_string(client.basic_password))\n"
+      + "  let basic = _client_basic(client)\n"
+      + "  let encoded = base64_encode(to_string(basic.user) + \":\" + to_string(basic.password))\n"
       + "  var hs = "
       + _render_binding_dict(
       ["Authorization: \"Basic \" + encoded", _harn_dict_entry("Content-Type", "\"application/json\"")],
@@ -843,9 +1266,9 @@ fn _render_auth_helper(scheme_name, def) {
       [
       _harn_dict_entry(
       header_name,
-      "to_string(client.api_keys.get(\""
+      "_client_api_key(client, \""
       + _escape_string(scheme_name)
-      + "\") ?? \"\")",
+      + "\")",
     ),
       _harn_dict_entry("Content-Type", "\"application/json\""),
     ],
@@ -865,9 +1288,9 @@ fn _render_auth_helper(scheme_name, def) {
       [
       "Cookie: \""
       + _escape_string(cookie_name)
-      + "=\" + to_string(client.api_keys.get(\""
+      + "=\" + _client_api_key(client, \""
       + _escape_string(scheme_name)
-      + "\") ?? \"\")",
+      + "\")",
       _harn_dict_entry("Content-Type", "\"application/json\""),
     ],
     )
@@ -897,10 +1320,10 @@ fn _render_auth_helper(scheme_name, def) {
       + "fn "
       + query_fn_name
       + "(client: dict) -> dict {\n"
-      + "  let v = client.api_keys.get(\""
+      + "  let v = _client_api_key(client, \""
       + _escape_string(scheme_name)
       + "\")\n"
-      + "  if v == nil {\n"
+      + "  if v == \"\" {\n"
       + "    return {}\n"
       + "  }\n"
       + "  return {"
@@ -1364,6 +1787,59 @@ fn _render_literal(value) {
   return json_stringify(value)
 }
 
+fn _render_data_literal(value) {
+  if value == nil {
+    return "nil"
+  }
+  if type_of(value) == "string" {
+    return "\"" + _escape_string(value) + "\""
+  }
+  if type_of(value) == "bool" || type_of(value) == "int" || type_of(value) == "float" {
+    return to_string(value)
+  }
+  if type_of(value) == "list" {
+    if len(value) == 0 {
+      return "[]"
+    }
+    var out = "[\n"
+    for item in value {
+      out = out + "    " + _indent_after_first(_render_data_literal(item), "    ") + ",\n"
+    }
+    out = out + "  ]"
+    return out
+  }
+  if type_of(value) == "dict" {
+    var parts = []
+    for entry in value {
+      if entry.value != nil {
+        parts = parts + [_harn_dict_entry(entry.key, _render_data_literal(entry.value))]
+      }
+    }
+    if len(parts) == 0 {
+      return "{}"
+    }
+    var out = "{\n"
+    for part in parts {
+      out = out + "    " + _indent_after_first(part, "    ") + ",\n"
+    }
+    out = out + "  }"
+    return out
+  }
+  return "\"" + _escape_string(to_string(value)) + "\""
+}
+
+fn _indent_after_first(src, indent) {
+  return replace(src, "\n", "\n" + indent)
+}
+
+fn _render_json_parse_expr(value) {
+  let encoded = _escape_string(json_stringify(value))
+  if len(encoded) <= 80 {
+    return "json_parse(\"" + encoded + "\")"
+  }
+  return "json_parse(\n    \"" + encoded + "\",\n  )"
+}
+
 // -----------------------------------------------------------------------------
 // Response type resolution
 // -----------------------------------------------------------------------------
@@ -1821,6 +2297,37 @@ fn _is_plain_identifier(s) {
 
 fn _escape_string(s) {
   return replace(replace(s, "\\", "\\\\"), "\"", "\\\"")
+}
+
+fn _escape_toml_string(s) {
+  return _escape_string(to_string(s))
+}
+
+fn _toml_key(key) {
+  if regex_match("^[A-Za-z0-9_-]+$", key) != nil {
+    return key
+  }
+  return "\"" + _escape_toml_string(key) + "\""
+}
+
+fn _render_manifest_dependency(name, spec) {
+  if type_of(spec) == "string" {
+    return _toml_key(name) + " = \"" + _escape_toml_string(spec) + "\"\n"
+  }
+  if type_of(spec) != "dict" {
+    return _toml_key(name) + " = \"*\"\n"
+  }
+  var parts = []
+  for key in ["path", "git", "rev", "branch", "tag", "version"] {
+    let value = spec.get(key)
+    if value != nil {
+      parts = parts + [_toml_key(key) + " = \"" + _escape_toml_string(value) + "\""]
+    }
+  }
+  if len(parts) == 0 {
+    return _toml_key(name) + " = {}\n"
+  }
+  return _toml_key(name) + " = { " + join(parts, ", ") + " }\n"
 }
 
 fn _render_dict_literal(d) {

--- a/src/types.harn
+++ b/src/types.harn
@@ -90,3 +90,9 @@ type Components = {schemas?: dict<string, Schema>, responses?: dict<string, RefO
 type OpenApiDoc = {openapi: string, info: Info, jsonSchemaDialect?: string, servers?: list<Server>, paths?: dict<string, PathItem>, webhooks?: dict<string, RefOr<PathItem>>, components?: Components, security?: list<SecurityRequirement>, tags?: list<Tag>, externalDocs?: ExternalDocumentation, security_schemes?: dict<string, RefOr<SecurityScheme>>}
 
 type WebhookOperation = {name: string, method: string, path_item: PathItem, operation: Operation, operation_id: string, summary?: string, description?: string, parameters?: list<RefOr<Parameter>>, request_body?: RefOr<RequestBody>, responses?: Responses, security?: list<SecurityRequirement>, tags?: list<string>}
+
+type AuthHelper = {scheme_name: string, kind: string, client_fields: list<string>, location?: string, parameter_name?: string, scopes?: list<string>}
+
+type PaginationPlan = {operation_id: string, method: string, path: string, kind: string, items_field?: string, cursor_param?: string, cursor_response_field?: string, has_more_field?: string, page_param?: string, page_size_param?: string, next_link_field?: string, link_header?: string}
+
+type RateLimitMetadata = {operation_id: string, method: string, path: string, status?: string, retry_after_header?: string, limit_headers: list<string>, remaining_headers: list<string>, reset_headers: list<string>}

--- a/tests/connector_helpers_smoke.harn
+++ b/tests/connector_helpers_smoke.harn
@@ -1,0 +1,149 @@
+// connector_helpers_smoke — issue #23 coverage for connector-facing auth,
+// pagination, rate-limit metadata, and generated helper source.
+import {
+  auth_helpers,
+  codegen_harn_toml,
+  codegen_module,
+  pagination_plans,
+  parse,
+  rate_limit_metadata,
+} from "../src/lib"
+
+fn harn_root() -> string {
+  let root = env("HARN_ROOT")
+  if root != nil && root != "" {
+    return root
+  }
+  return "/Users/ksinder/projects/harn"
+}
+
+fn harn_cmd(args: string) -> string {
+  let bin = env("HARN_BIN")
+  if bin != nil && bin != "" {
+    return "cd " + harn_root() + " && " + bin + " " + args
+  }
+  return "cd " + harn_root() + " && cargo run --quiet --bin harn -- " + args
+}
+
+fn assert_contains(haystack: string, needle: string, label: string) {
+  if !contains(haystack, needle) {
+    println("---BEGIN GENERATED SOURCE---")
+    println(haystack)
+    println("---END GENERATED SOURCE---")
+    assert(false, "${label}: expected source to contain \"${needle}\"")
+  }
+}
+
+fn helper_by_name(helpers, name) {
+  for helper in helpers {
+    if helper.scheme_name == name {
+      return helper
+    }
+  }
+  return nil
+}
+
+fn plan_by_id(plans, operation_id) {
+  for plan in plans {
+    if plan.operation_id == operation_id {
+      return plan
+    }
+  }
+  return nil
+}
+
+fn check_generates(src: string) {
+  let tmp_path = "/tmp/harn-openapi-connector-helpers-smoke.harn"
+  write_file(tmp_path, src)
+  let check_result = shell(harn_cmd("check " + tmp_path))
+  if !check_result.success {
+    println("---harn check stderr---")
+    println(check_result.stderr)
+    println("---harn check stdout---")
+    println(check_result.stdout)
+  }
+  assert(check_result.success, "generated SDK must pass `harn check`")
+  let fmt_result = shell(harn_cmd("fmt --check " + tmp_path))
+  if !fmt_result.success {
+    println("---harn fmt --check stderr---")
+    println(fmt_result.stderr)
+    println("---harn fmt --check stdout---")
+    println(fmt_result.stdout)
+  }
+  assert(fmt_result.success, "generated SDK must pass `harn fmt --check`")
+}
+
+@test
+pipeline default() {
+  let raw = read_file(source_dir() + "/fixtures/connector_helpers.openapi.json")
+  let doc = parse(raw)
+  let helpers = auth_helpers(doc)
+  let bearer = helper_by_name(helpers, "bearerAuth")
+  assert(bearer != nil, "bearerAuth helper metadata should exist")
+  assert(bearer.kind == "bearer", "bearerAuth should classify as bearer")
+  assert(
+    bearer.client_fields.contains("token_provider"),
+    "bearerAuth should advertise token_provider",
+  )
+  let oauth = helper_by_name(helpers, "oauth2Auth")
+  assert(oauth != nil, "oauth2Auth helper metadata should exist")
+  assert(oauth.kind == "oauth2", "oauth2Auth should classify as oauth2")
+  assert(oauth.scopes.contains("items:read"), "oauth2Auth should surface scopes")
+  let query_key = helper_by_name(helpers, "queryKey")
+  assert(query_key != nil, "queryKey helper metadata should exist")
+  assert(query_key.kind == "apiKey-query", "queryKey should classify as apiKey-query")
+  assert(query_key.parameter_name == "api_key", "queryKey should preserve parameter name")
+  let plans = pagination_plans(doc)
+  let cursor = plan_by_id(plans, "listItems")
+  assert(cursor != nil, "listItems should have a cursor pagination plan")
+  assert(cursor.kind == "cursor", "listItems should be cursor-pagination")
+  assert(cursor.cursor_param == "start_cursor", "cursor plan should preserve request cursor param")
+  assert(cursor.cursor_response_field == "next_cursor", "cursor plan should preserve response cursor")
+  assert(cursor.items_field == "results", "cursor plan should preserve items field")
+  let page = plan_by_id(plans, "listPageItems")
+  assert(page != nil && page.kind == "page", "listPageItems should have a page plan")
+  let next_link = plan_by_id(plans, "listNextLinkItems")
+  assert(
+    next_link != nil && next_link.kind == "next_link",
+    "listNextLinkItems should have a next-link plan",
+  )
+  let rates = rate_limit_metadata(doc)
+  assert(len(rates) == 1, "synthetic fixture should expose one rate-limit metadata entry")
+  assert(rates[0].operation_id == "listItems", "rate-limit metadata should be tied to listItems")
+  assert(rates[0].retry_after_header == "Retry-After", "Retry-After should be modeled")
+  assert(
+    rates[0].remaining_headers.contains("X-RateLimit-Remaining"),
+    "remaining header should be modeled",
+  )
+  let src = codegen_module(doc, {module_name: "connector_helpers", client_name: "Client"})
+  assert_contains(src, "pub fn token_from_secret", "generated token provider helper")
+  assert_contains(src, "token_provider = nil", "generated client token-provider hook")
+  assert_contains(src, "api_key_provider = nil", "generated client api-key-provider hook")
+  assert_contains(src, "_client_token(client)", "generated bearer helpers use token provider hook")
+  assert_contains(
+    src,
+    "_client_api_key(client, \"queryKey\")",
+    "generated apiKey helpers use provider hook",
+  )
+  assert_contains(src, "pub fn pagination_plans() -> list", "generated pagination plans helper")
+  assert_contains(src, "\\\"kind\\\":\\\"cursor\\\"", "generated cursor pagination metadata")
+  assert_contains(src, "pub fn rate_limit_metadata() -> list", "generated rate-limit metadata helper")
+  assert_contains(src, "Retry-After", "generated rate-limit header metadata")
+  check_generates(src)
+  let manifest = codegen_harn_toml(
+    {
+    package_name: "connector-helper-sdk",
+    description: "Synthetic generated SDK.",
+    default_export: "src/lib.harn",
+    dependencies: {["harn-openapi"]: {path: "../harn-openapi"}},
+  },
+  )
+  assert_contains(manifest, "name = \"connector-helper-sdk\"", "generated package name")
+  assert_contains(manifest, "default = \"src/lib.harn\"", "generated default export")
+  assert_contains(
+    manifest,
+    "harn-openapi = { path = \"../harn-openapi\" }",
+    "generated dependency declaration",
+  )
+  println("connector_helpers_smoke: ok")
+}

--- a/tests/fixtures/connector_helpers.openapi.json
+++ b/tests/fixtures/connector_helpers.openapi.json
@@ -1,0 +1,264 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Connector Helper Synthetic API",
+    "version": "0.0.1"
+  },
+  "servers": [
+    {
+      "url": "https://api.example.com"
+    }
+  ],
+  "security": [
+    {
+      "bearerAuth": []
+    },
+    {
+      "oauth2Auth": [
+        "items:read"
+      ]
+    }
+  ],
+  "paths": {
+    "/items": {
+      "get": {
+        "operationId": "listItems",
+        "summary": "List items",
+        "parameters": [
+          {
+            "name": "start_cursor",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page_size",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CursorPage"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "rate limited",
+            "headers": {
+              "Retry-After": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-RateLimit-Limit": {
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "X-RateLimit-Remaining": {
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "X-RateLimit-Reset": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/page-items": {
+      "get": {
+        "operationId": "listPageItems",
+        "summary": "List items by page number",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "per_page",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageNumberPage"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/next-link-items": {
+      "get": {
+        "operationId": "listNextLinkItems",
+        "summary": "List items with a next link",
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NextLinkPage"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/oauth-items": {
+      "get": {
+        "operationId": "listOauthItems",
+        "summary": "List OAuth items",
+        "security": [
+          {
+            "oauth2Auth": [
+              "items:read"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/keyed-items": {
+      "get": {
+        "operationId": "listKeyedItems",
+        "summary": "List API-key items",
+        "security": [
+          {
+            "queryKey": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer"
+      },
+      "oauth2Auth": {
+        "type": "oauth2",
+        "flows": {
+          "clientCredentials": {
+            "tokenUrl": "https://api.example.com/oauth/token",
+            "scopes": {
+              "items:read": "Read items"
+            }
+          }
+        }
+      },
+      "queryKey": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "api_key"
+      }
+    },
+    "schemas": {
+      "CursorPage": {
+        "type": "object",
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "next_cursor": {
+            "type": "string"
+          },
+          "has_more": {
+            "type": "boolean"
+          }
+        }
+      },
+      "PageNumberPage": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "page": {
+            "type": "integer"
+          }
+        }
+      },
+      "NextLinkPage": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "next_url": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/security_smoke.harn
+++ b/tests/security_smoke.harn
@@ -99,10 +99,11 @@ pipeline default() {
   )
   let src_a = codegen_module(parse(doc_a), {module_name: "a", client_name: "A"})
   assert_contains(src_a, "_headers_bearerauth(client)", "A/dispatch")
-  assert_contains(src_a, "Authorization: \"Bearer \" + to_string(client.token)", "A/bearer-helper")
+  assert_contains(src_a, "Authorization: \"Bearer \" + _client_token(client)", "A/bearer-helper")
   assert_contains(src_a, "token: string = \"\"", "A/client-has-token")
-  assert_not_contains(src_a, "basic_user", "A/no-basic-field")
-  assert_not_contains(src_a, "api_keys", "A/no-apikey-field")
+  assert_contains(src_a, "token_provider = nil", "A/client-has-token-provider")
+  assert_not_contains(src_a, "basic_user: string", "A/no-basic-field")
+  assert_not_contains(src_a, "api_keys: dict", "A/no-apikey-field")
   check_generates(src_a, "A")
   // ------------------------------------------------------------------
   // Scenario B: explicit security: [] on one op overrides doc default.
@@ -156,7 +157,7 @@ pipeline default() {
   assert_contains(src_c, "Authorization: \"Basic \" + encoded", "C/basic-header")
   assert_contains(src_c, "basic_user: string = \"\"", "C/client-has-basic-user")
   assert_contains(src_c, "basic_password: string = \"\"", "C/client-has-basic-password")
-  assert_not_contains(src_c, "token:", "C/no-token-field")
+  assert_not_contains(src_c, "token: string", "C/no-token-field")
   check_generates(src_c, "C")
   // ------------------------------------------------------------------
   // Scenario D: apiKey in header.
@@ -169,9 +170,10 @@ pipeline default() {
   let src_d = codegen_module(parse(doc_d), {module_name: "d", client_name: "D"})
   assert_contains(src_d, "_headers_xapikey(client)", "D/dispatch")
   assert_contains(src_d, "[\"X-Api-Key\"]:", "D/header-name-emitted")
-  assert_contains(src_d, "client.api_keys.get(\"xApiKey\")", "D/reads-from-api-keys")
+  assert_contains(src_d, "_client_api_key(client, \"xApiKey\")", "D/reads-from-api-keys")
   assert_contains(src_d, "api_keys: dict = {}", "D/client-has-api-keys")
-  assert_not_contains(src_d, "token:", "D/no-token-field")
+  assert_contains(src_d, "api_key_provider = nil", "D/client-has-api-key-provider")
+  assert_not_contains(src_d, "token: string", "D/no-token-field")
   check_generates(src_d, "D")
   // ------------------------------------------------------------------
   // Scenario E: apiKey in query.
@@ -198,7 +200,7 @@ pipeline default() {
   let src_f = codegen_module(parse(doc_f), {module_name: "f", client_name: "F"})
   assert_contains(src_f, "_headers_sessid(client)", "F/dispatch")
   assert_contains(src_f, "Cookie: \"sid=\" +", "F/cookie-header")
-  assert_contains(src_f, "client.api_keys.get(\"sessId\")", "F/reads-from-api-keys")
+  assert_contains(src_f, "_client_api_key(client, \"sessId\")", "F/reads-from-api-keys")
   check_generates(src_f, "F")
   // ------------------------------------------------------------------
   // Scenario G: oauth2 — treated as bearer for v0 (client already holds token).
@@ -215,8 +217,9 @@ pipeline default() {
   )
   let src_g = codegen_module(parse(doc_g), {module_name: "g", client_name: "G"})
   assert_contains(src_g, "_headers_oauth2auth(client)", "G/dispatch")
-  assert_contains(src_g, "Authorization: \"Bearer \" + to_string(client.token)", "G/bearer-shape")
+  assert_contains(src_g, "Authorization: \"Bearer \" + _client_token(client)", "G/bearer-shape")
   assert_contains(src_g, "token: string = \"\"", "G/client-has-token")
+  assert_contains(src_g, "token_provider = nil", "G/client-has-token-provider")
   check_generates(src_g, "G")
   // ------------------------------------------------------------------
   // Scenario H: mixed schemes (bearer + basic) with per-op overrides,

--- a/tests/types_smoke.harn
+++ b/tests/types_smoke.harn
@@ -19,5 +19,12 @@ pipeline default() {
   let enum_schema: Schema = {type: "string", enum: ["a", "b"]}
   let values = enum_values(enum_schema)
   require values != nil && len(values) == 2, "enum_values should preserve typed enum lists"
+  let synthetic = parse(read_file(source_dir() + "/fixtures/connector_helpers.openapi.json"))
+  let helpers: list<AuthHelper> = auth_helpers(synthetic)
+  require helpers[0].scheme_name != nil, "AuthHelper should expose scheme_name"
+  let pages: list<PaginationPlan> = pagination_plans(synthetic)
+  require pages[0].operation_id != nil, "PaginationPlan should expose operation_id"
+  let rates: list<RateLimitMetadata> = rate_limit_metadata(synthetic)
+  require rates[0].retry_after_header == "Retry-After", "RateLimitMetadata should expose retry headers"
   println("types_smoke: ok")
 }


### PR DESCRIPTION
## Summary

Implements connector-facing SDK generator helpers for harn-openapi#23.

- adds public metadata walkers for auth helpers, pagination plans, and rate-limit response/header conventions
- updates generated SDK modules with SecretProvider-friendly token/API-key hooks, pagination helpers, and rate-limit helpers
- adds `codegen_harn_toml(...)` so generated SDK repos can emit package metadata and dependency declarations
- adds a small synthetic OpenAPI fixture covering bearer/OAuth/apiKey security alternatives, cursor/page/next-link pagination, and 429 rate-limit headers
- updates README and existing security/type smoke coverage for the new generated client shape

## Validation

- `cargo run --quiet --bin harn -- check /Users/ksinder/.codex/worktrees/8557/harn-openapi/src/lib.harn`
- `cargo run --quiet --bin harn -- lint /Users/ksinder/.codex/worktrees/8557/harn-openapi/src/lib.harn`
- `cargo run --quiet --bin harn -- fmt --check /Users/ksinder/.codex/worktrees/8557/harn-openapi/src /Users/ksinder/.codex/worktrees/8557/harn-openapi/tests`
- `for t in /Users/ksinder/.codex/worktrees/8557/harn-openapi/tests/*.harn; do cargo run --quiet --bin harn -- run "$t" || exit 1; done`
- `cargo run --quiet --bin harn -- run /Users/ksinder/.codex/worktrees/8557/harn-openapi/scripts/regen_demo.harn`
- temp package smoke: `harn add --path ... harn-openapi`, `harn install`, `harn package cache verify --materialized`, then `harn check`/`harn run` against the materialized package source

Closes #23.
