### PR TITLE
Add CI status rollup gate to satisfy org rule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,3 +103,17 @@ jobs:
         run: |
           "$HARN_BIN" run scripts/package_install_smoke.harn
         working-directory: harn-openapi
+
+  ci-status:
+    name: CI status
+    if: always()
+    needs: [harn]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for failures
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "One or more CI jobs failed"
+            exit 1
+          fi
+          echo "All CI jobs passed or were skipped"


### PR DESCRIPTION
Adds a rollup job named `CI status` (needs `[harn]`) to satisfy the `burin-labs/main protection` org ruleset which requires that exact context name.