### PR TITLE
feat: throw structured dict on non-2xx in generated SDKs

### DIFF
--- a/src/lib.harn
+++ b/src/lib.harn
@@ -1147,7 +1147,7 @@ let _MODULE_TEMPLATE = """
     {{ if op.has_body }}{{ op.body_prepare }}
     let resp = http_{{ op.method }}(url, body_str, {headers: {{ op.headers_call }}}){{ else }}let resp = http_{{ op.method }}(url, {headers: {{ op.headers_call }}}){{ end }}
     if resp.status >= 400 {
-      throw "{{ op.fn_name }}: HTTP " + to_string(resp.status) + " " + resp.body
+      {{ op.error_throw }}
     }
     {{ if op.returns_nil }}return nil{{ else }}let raw = json_parse(resp.body)
     if type_of(raw) != "dict" {
@@ -1678,7 +1678,31 @@ fn _build_op_model(doc, op, taken_names, choice, schemes, ret) {
     security_note: security_note,
     return_type: ret.type_name,
     returns_nil: ret.returns_nil,
+    error_throw: _render_error_throw(fn_name),
   }
+}
+
+/**
+ * Build the `throw { ... }` statement for non-2xx responses, matching
+ * `harn fmt` width logic so the generated source is already canonical.
+ * The dict literal alone wraps when `1 + inline.len() + 1 > 100`
+ * (see crates/harn-fmt/src/formatter/mod.rs::format_comma_sequence).
+ */
+fn _render_error_throw(fn_name) {
+  let dict_inline = "operation: \""
+    + fn_name
+    + "\", status: resp.status, body: resp.body, headers: resp.headers"
+  if 2 + len(dict_inline) <= 100 {
+    return "throw {" + dict_inline + "}"
+  }
+  return "throw {\n"
+    + "      operation: \""
+    + fn_name
+    + "\",\n"
+    + "      status: resp.status,\n"
+    + "      body: resp.body,\n"
+    + "      headers: resp.headers,\n"
+    + "    }"
 }
 
 fn path_bindings_parts_render(parts) {

--- a/tests/error_throw_smoke.harn
+++ b/tests/error_throw_smoke.harn
@@ -1,0 +1,92 @@
+// error_throw_smoke — verify that generated SDK functions throw a
+// structured dict (not a string) on non-2xx HTTP responses, so callers
+// can pattern-match on `status` / `body` / `headers` / `operation`
+// without parsing strings.
+import { codegen_module, parse } from "../src/lib"
+
+fn harn_root() -> string {
+  let root = env("HARN_ROOT")
+  if root != nil && root != "" {
+    return root
+  }
+  return "/Users/ksinder/projects/harn"
+}
+
+fn harn_cmd(args: string) -> string {
+  let bin = env("HARN_BIN")
+  if bin != nil && bin != "" {
+    return "cd " + harn_root() + " && " + bin + " " + args
+  }
+  return "cd " + harn_root() + " && cargo run --quiet --bin harn -- " + args
+}
+
+fn build_doc() -> string {
+  return json_stringify(
+    {
+      openapi: "3.1.0",
+      info: {title: "Throw Test", version: "0.0.1"},
+      servers: [{url: "https://api.example.com"}],
+      paths: {"/v1/thing": {get: {operationId: "get-thing", responses: {"200": {description: "ok"}}}}},
+      components: {securitySchemes: {bearerAuth: {type: "http", scheme: "bearer"}}},
+      security: [{bearerAuth: []}],
+    },
+  )
+}
+
+@test
+pipeline default() {
+  let src = codegen_module(parse(build_doc()), {module_name: "throw_t", client_name: "T"})
+  // The throw site must emit a dict literal carrying operation, status,
+  // body, and headers — and must NOT emit the legacy string format.
+  assert(
+    contains(src, "throw {operation: \"get_thing\""),
+    "generated source must throw a dict, not a string",
+  )
+  assert(
+    contains(src, "headers: resp.headers"),
+    "generated dict must carry resp.headers for downstream request_id parsing",
+  )
+  assert(
+    !contains(src, "throw \"get_thing: HTTP \""),
+    "legacy string-throw format must be gone for non-2xx responses",
+  )
+  // Drive the generated function against a mocked 404 and assert the
+  // thrown payload's shape.
+  let module_stem = "/tmp/harn-openapi-error-throw-smoke"
+  let module_path = module_stem + ".harn"
+  let runner_path = "/tmp/harn-openapi-error-throw-runtime.harn"
+  write_file(module_path, src)
+  let body_lit = "{\"code\":\"not_found\",\"message\":\"missing\"}"
+  let runner = "import { new_client, get_thing } from \"" + module_stem + "\"\n"
+    + "\n"
+    + "@test\n"
+    + "pipeline default() {\n"
+    + "  http_mock_clear()\n"
+    + "  http_mock(\"GET\", \"https://api.example.com/v1/thing\", "
+    + "{status: 404, body: "
+    + json_stringify(body_lit)
+    + ", "
+    + "headers: {\"x-request-id\": \"req-123\", \"content-type\": \"application/json\"}})\n"
+    + "  let client = new_client(\"https://api.example.com\", \"tok\")\n"
+    + "  let caught = try { get_thing(client); nil } catch (e) { e }\n"
+    + "  assert(type_of(caught) == \"dict\", \"expected dict throw\")\n"
+    + "  assert_eq(caught.operation, \"get_thing\")\n"
+    + "  assert_eq(caught.status, 404)\n"
+    + "  assert_eq(caught.body, "
+    + json_stringify(body_lit)
+    + ")\n"
+    + "  assert_eq(type_of(caught.headers), \"dict\")\n"
+    + "  assert_eq(caught.headers[\"x-request-id\"], \"req-123\")\n"
+    + "  println(\"error_throw runtime: ok\")\n"
+    + "}\n"
+  write_file(runner_path, runner)
+  let result = shell(harn_cmd("run " + runner_path))
+  if !result.success {
+    println("---runtime stderr---")
+    println(result.stderr)
+    println("---runtime stdout---")
+    println(result.stdout)
+  }
+  assert(result.success, "generated SDK must throw a dict on 404")
+  println("error_throw_smoke: ok")
+}


### PR DESCRIPTION
## Summary

- Generated SDK functions now throw `{operation, status, body, headers}` dicts on non-2xx HTTP responses instead of the legacy `"<fn>: HTTP <status> <body>"` string. Callers can pattern-match on the dict (e.g. read `headers["x-request-id"]` for the Notion request id, or JSON-parse `body` to recover the API error payload) without string-parsing.
- The dict literal is pre-formatted in `_render_error_throw` to match `harn fmt`'s width logic so generated source stays canonical: inline when `fn_name` is short, wrapped to one-field-per-line otherwise.
- Internal codegen errors (`expected dict response`, polymorphic body variant errors) are intentionally left as strings — they are program bugs, not API errors, and have stable string formats consumers don't rely on.

## Downstream impact

This unblocks two downstream consumers:

1. `notion-sdk-harn`'s `decode_thrown` already handles dict-shape input via its `_from_dict` branch — once the harn-openapi pin bumps and regen runs, the legacy string-parsing branch becomes dead code and `request_id` will start populating from `headers.x-request-id`.
2. `harn-notion-connector`'s `__sdk_error` (a 35-line string parser) can simplify to a small dict reshaper.

Both bumps are intentionally left as follow-up PRs in their respective repos.

## Test plan

- [x] `harn check src scripts tests` passes
- [x] `harn lint src scripts` passes
- [x] `harn fmt --check src scripts tests` passes
- [x] All 14 tests pass (`tests/*.harn`), including the existing `security_smoke.harn` (mocked-HTTP scenarios A–J)
- [x] New `tests/error_throw_smoke.harn` asserts both the codegen output (`throw {operation: "get_thing"...`) and the runtime shape (catches the throw from a 404 mock and verifies `caught.status == 404`, `caught.headers["x-request-id"] == "req-123"`, etc.)
- [x] `scripts/regen_demo.harn` regenerates the Notion SDK against the pinned fixture and the output passes `harn check` + `harn fmt --check`