### PR TITLE
chore: clean up pre-existing lint warnings (template + tests)

### DIFF
--- a/src/lib.harn
+++ b/src/lib.harn
@@ -1018,6 +1018,7 @@ let _MODULE_TEMPLATE = """
     return {{ pagination_plan_literal }}
   }
 
+  /** Look up the pagination plan for a given operation id, or nil if none. */
   pub fn pagination_plan(operation_id: string) -> dict? {
     for plan in pagination_plans() {
       if plan.operation_id == operation_id {
@@ -1027,6 +1028,7 @@ let _MODULE_TEMPLATE = """
     return nil
   }
 
+  /** Extract the items list from `response` according to `plan`. */
   pub fn pagination_items(response: dict, plan: dict) -> list {
     let field = plan.get("items_field")
     if field == nil {
@@ -1039,6 +1041,11 @@ let _MODULE_TEMPLATE = """
     return []
   }
 
+  /**
+   * Compute the next-page directive from `response` according to `plan`.
+   * Returns a dict with `done: bool` plus either a `query` dict to merge
+   * into the next call, or a `url` to follow (next-link style).
+   */
   pub fn pagination_next(response: dict, plan: dict) -> dict {
     let kind = plan.get("kind")
     if kind == "cursor" {
@@ -1054,7 +1061,7 @@ let _MODULE_TEMPLATE = """
       } else {
         response.get(has_more_field)
       }
-      return {done: cursor == nil || has_more == false, query: {[plan.cursor_param]: cursor}}
+      return {done: cursor == nil || !has_more, query: {[plan.cursor_param]: cursor}}
     }
     if kind == "page" {
       return {done: false, query: {}}
@@ -1085,6 +1092,7 @@ let _MODULE_TEMPLATE = """
     return nil
   }
 
+  /** Extract status + standard rate-limit headers from a raw HTTP response. */
   pub fn rate_limit_from_response(resp: dict) -> dict {
     let headers = resp.get("headers") ?? {}
     return {
@@ -1096,6 +1104,7 @@ let _MODULE_TEMPLATE = """
     }
   }
 
+  /** True if the response looks rate-limited (HTTP 429 or Retry-After set). */
   pub fn is_rate_limited_response(resp: dict) -> bool {
     let headers = resp.get("headers") ?? {}
     return resp.get("status") == 429 || _header_ci(headers, "Retry-After") != nil
@@ -2002,9 +2011,12 @@ fn _render_body_variant_constructor(variant) {
       ]
     }
   }
+  let doc_comment = "/** Build a `" + _escape_string(variant.tag)
+    + "` variant of the polymorphic request body. */\n"
   let sig_parts = required_sig + optional_sig
   if len(sig_parts) == 0 && len(literal_entries) == 0 {
-    return "pub fn "
+    return doc_comment
+      + "pub fn "
       + variant.fn_name
       + "(payload: dict) -> dict {\n"
       + "  return {...payload, _variant: \""
@@ -2013,7 +2025,12 @@ fn _render_body_variant_constructor(variant) {
       + "}"
   }
   literal_entries = literal_entries + [_harn_dict_entry("_variant", "\"" + _escape_string(variant.tag) + "\"")]
-  var body = "pub fn " + variant.fn_name + "(" + join(sig_parts, ", ") + ") -> dict {\n"
+  var body = doc_comment
+    + "pub fn "
+    + variant.fn_name
+    + "("
+    + join(sig_parts, ", ")
+    + ") -> dict {\n"
   body = body + "  var body = " + _render_binding_dict(literal_entries) + "\n"
   for line in optional_lines {
     body = body + line + "\n"

--- a/tests/bump_harn_cli_version_smoke.harn
+++ b/tests/bump_harn_cli_version_smoke.harn
@@ -28,7 +28,7 @@ fn cat_file(path: string) -> string {
   return result.stdout
 }
 
-pipeline default() {
+pipeline test_main() {
   let repo_root = source_dir() + "/.."
   let fake_root = temp_dir() + "/harn-openapi-bump-smoke-" + uuid()
   mkdir(fake_root)
@@ -45,10 +45,10 @@ pipeline default() {
     println(result.stderr)
     println(result.stdout)
   }
-  require result.success, "bump_harn_cli_version.harn must run"
-  require contains(result.stdout, "0.0.1 -> 9.8.7"), "script should report version update"
-  require contains(result.stdout, "skipped verification"), "test path should skip the full gate"
+  assert(result.success, "bump_harn_cli_version.harn must run")
+  assert(contains(result.stdout, "0.0.1 -> 9.8.7"), "script should report version update")
+  assert(contains(result.stdout, "skipped verification"), "test path should skip the full gate")
   let version = cat_file(fake_root + "/.harn-version")
-  require version == "9.8.7\n", ".harn-version must update"
+  assert_eq(version, "9.8.7\n")
   println("bump_harn_cli_version_smoke: ok")
 }

--- a/tests/codegen_smoke.harn
+++ b/tests/codegen_smoke.harn
@@ -19,7 +19,7 @@ fn harn_cmd(args: string) -> string {
   return "cd " + harn_root() + " && cargo run --quiet --bin harn -- " + args
 }
 
-pipeline default() {
+pipeline test_main() {
   let raw = read_file(source_dir() + "/fixtures/notion.openapi.json")
   let doc = parse(raw)
   let src = codegen_module(

--- a/tests/connector_helpers_smoke.harn
+++ b/tests/connector_helpers_smoke.harn
@@ -25,12 +25,12 @@ fn harn_cmd(args: string) -> string {
   return "cd " + harn_root() + " && cargo run --quiet --bin harn -- " + args
 }
 
-fn assert_contains(haystack: string, needle: string, label: string) {
+fn require_contains(haystack: string, needle: string, label: string) {
   if !contains(haystack, needle) {
     println("---BEGIN GENERATED SOURCE---")
     println(haystack)
     println("---END GENERATED SOURCE---")
-    assert(false, "${label}: expected source to contain \"${needle}\"")
+    require false, "${label}: expected source to contain \"${needle}\""
   }
 }
 
@@ -62,7 +62,7 @@ fn check_generates(src: string) {
     println("---harn check stdout---")
     println(check_result.stdout)
   }
-  assert(check_result.success, "generated SDK must pass `harn check`")
+  require check_result.success, "generated SDK must pass `harn check`"
   let fmt_result = shell(harn_cmd("fmt --check " + tmp_path))
   if !fmt_result.success {
     println("---harn fmt --check stderr---")
@@ -70,11 +70,11 @@ fn check_generates(src: string) {
     println("---harn fmt --check stdout---")
     println(fmt_result.stdout)
   }
-  assert(fmt_result.success, "generated SDK must pass `harn fmt --check`")
+  require fmt_result.success, "generated SDK must pass `harn fmt --check`"
 }
 
 @test
-pipeline default() {
+pipeline test_main() {
   let raw = read_file(source_dir() + "/fixtures/connector_helpers.openapi.json")
   let doc = parse(raw)
   let helpers = auth_helpers(doc)
@@ -116,19 +116,23 @@ pipeline default() {
     "remaining header should be modeled",
   )
   let src = codegen_module(doc, {module_name: "connector_helpers", client_name: "Client"})
-  assert_contains(src, "pub fn token_from_secret", "generated token provider helper")
-  assert_contains(src, "token_provider = nil", "generated client token-provider hook")
-  assert_contains(src, "api_key_provider = nil", "generated client api-key-provider hook")
-  assert_contains(src, "_client_token(client)", "generated bearer helpers use token provider hook")
-  assert_contains(
+  require_contains(src, "pub fn token_from_secret", "generated token provider helper")
+  require_contains(src, "token_provider = nil", "generated client token-provider hook")
+  require_contains(src, "api_key_provider = nil", "generated client api-key-provider hook")
+  require_contains(src, "_client_token(client)", "generated bearer helpers use token provider hook")
+  require_contains(
     src,
     "_client_api_key(client, \"queryKey\")",
     "generated apiKey helpers use provider hook",
   )
-  assert_contains(src, "pub fn pagination_plans() -> list", "generated pagination plans helper")
-  assert_contains(src, "\\\"kind\\\":\\\"cursor\\\"", "generated cursor pagination metadata")
-  assert_contains(src, "pub fn rate_limit_metadata() -> list", "generated rate-limit metadata helper")
-  assert_contains(src, "Retry-After", "generated rate-limit header metadata")
+  require_contains(src, "pub fn pagination_plans() -> list", "generated pagination plans helper")
+  require_contains(src, "\\\"kind\\\":\\\"cursor\\\"", "generated cursor pagination metadata")
+  require_contains(
+    src,
+    "pub fn rate_limit_metadata() -> list",
+    "generated rate-limit metadata helper",
+  )
+  require_contains(src, "Retry-After", "generated rate-limit header metadata")
   check_generates(src)
   let manifest = codegen_harn_toml(
     {
@@ -138,9 +142,9 @@ pipeline default() {
       dependencies: {"harn-openapi": {path: "../harn-openapi"}},
     },
   )
-  assert_contains(manifest, "name = \"connector-helper-sdk\"", "generated package name")
-  assert_contains(manifest, "default = \"src/lib.harn\"", "generated default export")
-  assert_contains(
+  require_contains(manifest, "name = \"connector-helper-sdk\"", "generated package name")
+  require_contains(manifest, "default = \"src/lib.harn\"", "generated default export")
+  require_contains(
     manifest,
     "harn-openapi = { path = \"../harn-openapi\" }",
     "generated dependency declaration",

--- a/tests/error_throw_smoke.harn
+++ b/tests/error_throw_smoke.harn
@@ -34,7 +34,7 @@ fn build_doc() -> string {
 }
 
 @test
-pipeline default() {
+pipeline test_main() {
   let src = codegen_module(parse(build_doc()), {module_name: "throw_t", client_name: "T"})
   // The throw site must emit a dict literal carrying operation, status,
   // body, and headers — and must NOT emit the legacy string format.

--- a/tests/fixture_workflow_smoke.harn
+++ b/tests/fixture_workflow_smoke.harn
@@ -15,7 +15,7 @@ fn harn_cmd(args: string) -> string {
   return "cd " + harn_root() + " && cargo run --quiet --bin harn -- " + args
 }
 
-pipeline default() {
+pipeline test_main() {
   let repo_root = source_dir() + "/.."
   let unique = to_string(to_int(timestamp())) + "-" + uuid()
   let old_path = temp_dir() + "/harn-openapi-old-" + unique + ".json"
@@ -99,23 +99,26 @@ pipeline default() {
     println(diff.stderr)
     println(diff.stdout)
   }
-  require diff.success, "fixture_diff.harn must run"
-  require contains(diff.stdout, "added operations:"), "diff output must include added operations"
-  require contains(diff.stdout, "POST /widgets (create-widget)"), "diff output must include added op"
-  require contains(diff.stdout, "removed operations:"), "diff output must include removed operations"
-  require contains(diff.stdout, "PATCH /legacy (patch-legacy)"), "diff output must include removed op"
-  require contains(diff.stdout, "added schemas:"), "diff output must include added schemas"
-  require contains(diff.stdout, "NewThing"), "diff output must include added schema"
-  require contains(diff.stdout, "removed schemas:"), "diff output must include removed schemas"
-  require contains(diff.stdout, "Legacy"), "diff output must include removed schema"
-  require contains(diff.stdout, "Widget (+1 fields, -1 fields)"), "diff output must summarize schema field changes"
+  assert(diff.success, "fixture_diff.harn must run")
+  assert(contains(diff.stdout, "added operations:"), "diff output must include added operations")
+  assert(contains(diff.stdout, "POST /widgets (create-widget)"), "diff output must include added op")
+  assert(contains(diff.stdout, "removed operations:"), "diff output must include removed operations")
+  assert(contains(diff.stdout, "PATCH /legacy (patch-legacy)"), "diff output must include removed op")
+  assert(contains(diff.stdout, "added schemas:"), "diff output must include added schemas")
+  assert(contains(diff.stdout, "NewThing"), "diff output must include added schema")
+  assert(contains(diff.stdout, "removed schemas:"), "diff output must include removed schemas")
+  assert(contains(diff.stdout, "Legacy"), "diff output must include removed schema")
+  assert(
+    contains(diff.stdout, "Widget (+1 fields, -1 fields)"),
+    "diff output must summarize schema field changes",
+  )
   let stale_cmd = harn_cmd("run " + repo_root + "/scripts/check_fixture_staleness.harn")
   let stale = shell(stale_cmd)
   if !stale.success {
     println(stale.stderr)
     println(stale.stdout)
   }
-  require stale.success, "check_fixture_staleness.harn must pass for committed metadata"
-  require contains(stale.stdout, "fixture staleness: ok"), "fixture should not be stale yet"
+  assert(stale.success, "check_fixture_staleness.harn must pass for committed metadata")
+  assert(contains(stale.stdout, "fixture staleness: ok"), "fixture should not be stale yet")
   println("fixture_workflow_smoke: ok")
 }

--- a/tests/parse_smoke.harn
+++ b/tests/parse_smoke.harn
@@ -5,7 +5,7 @@
 // Keep it pinned — do not auto-refresh.
 import { operations, parse } from "../src/lib"
 
-pipeline default() {
+pipeline test_main() {
   let raw = read_file(source_dir() + "/fixtures/notion.openapi.json")
   let doc = parse(raw)
   assert(starts_with(doc.openapi, "3.1"), "openapi version must be 3.1.x")

--- a/tests/polymorphic_body_smoke.harn
+++ b/tests/polymorphic_body_smoke.harn
@@ -133,12 +133,12 @@ fn count_occurrences(haystack: string, needle: string) -> int {
   return count
 }
 
-fn assert_contains(haystack: string, needle: string, label: string) {
+fn require_contains(haystack: string, needle: string, label: string) {
   if !contains(haystack, needle) {
     println("---BEGIN GENERATED SOURCE---")
     println(haystack)
     println("---END GENERATED SOURCE---")
-    assert(false, "${label}: expected generated source to contain ${needle}")
+    require false, "${label}: expected generated source to contain ${needle}"
   }
 }
 
@@ -150,7 +150,7 @@ fn check_file(path: string, label: string) {
     println("---${label} harn check stdout---")
     println(result.stdout)
   }
-  assert(result.success, "${label}: generated module must pass harn check")
+  require result.success, "${label}: generated module must pass harn check"
 }
 
 fn run_file(path: string, label: string) {
@@ -161,10 +161,10 @@ fn run_file(path: string, label: string) {
     println("---${label} harn run stdout---")
     println(result.stdout)
   }
-  assert(result.success, "${label}: generated module runtime smoke must pass")
+  require result.success, "${label}: generated module runtime smoke must pass"
 }
 
-pipeline default() {
+pipeline test_main() {
   let doc = parse(_POLY_DOC)
   let src = codegen_module(
     doc,
@@ -177,14 +177,14 @@ pipeline default() {
   )
   let out_path = "/tmp/harn-openapi-polymorphic-generated.harn"
   write_file(out_path, src)
-  assert_contains(src, "pub fn update_pet(client: dict, pet_id, body) -> dict", "umbrella")
-  assert_contains(src, "pub fn update_pet_cat_update(meow: string, lives = nil) -> dict", "cat ctor")
-  assert_contains(src, "pub fn update_pet_dog_update(bark: bool) -> dict", "dog ctor")
-  assert_contains(src, "if ![\"cat\", \"dog\"].contains(body_variant)", "discriminator tags")
-  assert_contains(src, "kind: \"cat\"", "cat const discriminator")
-  assert_contains(src, "_variant: \"cat\"", "cat internal tag")
-  assert_contains(src, "pub fn submit_shape_circle_shape(radius: float) -> dict", "anyOf ctor")
-  assert_contains(src, "pub fn submit_shape_square_shape(side: float) -> dict", "anyOf ctor")
+  require_contains(src, "pub fn update_pet(client: dict, pet_id, body) -> dict", "umbrella")
+  require_contains(src, "pub fn update_pet_cat_update(meow: string, lives = nil) -> dict", "cat ctor")
+  require_contains(src, "pub fn update_pet_dog_update(bark: bool) -> dict", "dog ctor")
+  require_contains(src, "if ![\"cat\", \"dog\"].contains(body_variant)", "discriminator tags")
+  require_contains(src, "kind: \"cat\"", "cat const discriminator")
+  require_contains(src, "_variant: \"cat\"", "cat internal tag")
+  require_contains(src, "pub fn submit_shape_circle_shape(radius: float) -> dict", "anyOf ctor")
+  require_contains(src, "pub fn submit_shape_square_shape(side: float) -> dict", "anyOf ctor")
   check_file(out_path, "poly")
   let runner_path = "/tmp/harn-openapi-polymorphic-runner.harn"
   write_file(
@@ -224,33 +224,33 @@ pipeline default() {
       header_overrides: {"Notion-Version": "2025-09-03"},
     },
   )
-  assert_contains(
+  require_contains(
     notion_src,
     "pub fn update_page_markdown(client: dict, page_id, body) -> PageMarkdownResponse",
     "notion umbrella",
   )
-  assert_contains(
+  require_contains(
     notion_src,
     "pub fn update_page_markdown_insert_content(insert_content: dict) -> dict",
     "notion insert_content ctor",
   )
-  assert_contains(
+  require_contains(
     notion_src,
     "pub fn update_page_markdown_replace_content_range(replace_content_range: dict) -> dict",
     "notion replace_content_range ctor",
   )
-  assert_contains(
+  require_contains(
     notion_src,
     "pub fn update_page_markdown_update_content(update_content: dict) -> dict",
     "notion update_content ctor",
   )
-  assert_contains(
+  require_contains(
     notion_src,
     "pub fn update_page_markdown_replace_content(replace_content: dict) -> dict",
     "notion replace_content ctor",
   )
   let notion_ctors = count_occurrences(notion_src, "pub fn update_page_markdown_")
   assert(notion_ctors == 4, "expected four Notion markdown constructors, got ${notion_ctors}")
-  assert_contains(notion_src, "_strip_codegen_variant(body)", "notion strips _variant")
+  require_contains(notion_src, "_strip_codegen_variant(body)", "notion strips _variant")
   println("polymorphic_body_smoke: ok")
 }

--- a/tests/ref_siblings_smoke.harn
+++ b/tests/ref_siblings_smoke.harn
@@ -39,7 +39,7 @@ let _TINY_DOC = """
   }
   """
 
-pipeline default() {
+pipeline test_main() {
   let doc = parse(_TINY_DOC)
   let bare = schema(doc, {"$ref": "#/components/schemas/BaseObject"})
   assert(bare.get("$ref") == nil, "bare $ref should resolve to the target schema")

--- a/tests/render_string_smoke.harn
+++ b/tests/render_string_smoke.harn
@@ -3,7 +3,7 @@
 // keeps the public helper covered on its own.
 import { render_string } from "../src/lib"
 
-pipeline default() {
+pipeline test_main() {
   let template = """
     Hello {{ user.name }}
     {{ if show }}shown{{ else }}hidden{{ end }}

--- a/tests/response_types_smoke.harn
+++ b/tests/response_types_smoke.harn
@@ -151,7 +151,7 @@ fn _count_occurrences(haystack: string, needle: string) -> int {
   return count
 }
 
-pipeline default() {
+pipeline test_main() {
   let doc = parse(_TINY_DOC)
   let src = codegen_module(
     doc,

--- a/tests/security_smoke.harn
+++ b/tests/security_smoke.harn
@@ -43,21 +43,21 @@ fn build_doc(sec_schemes: dict, doc_security, ops: list) -> string {
   return json_stringify(root)
 }
 
-fn assert_contains(haystack: string, needle: string, label: string) {
+fn require_contains(haystack: string, needle: string, label: string) {
   if !contains(haystack, needle) {
     println("---BEGIN GENERATED SOURCE---")
     println(haystack)
     println("---END GENERATED SOURCE---")
-    assert(false, "${label}: expected source to contain \"${needle}\"")
+    require false, "${label}: expected source to contain \"${needle}\""
   }
 }
 
-fn assert_not_contains(haystack: string, needle: string, label: string) {
+fn require_not_contains(haystack: string, needle: string, label: string) {
   if contains(haystack, needle) {
     println("---BEGIN GENERATED SOURCE---")
     println(haystack)
     println("---END GENERATED SOURCE---")
-    assert(false, "${label}: expected source NOT to contain \"${needle}\"")
+    require false, "${label}: expected source NOT to contain \"${needle}\""
   }
 }
 
@@ -71,7 +71,7 @@ fn check_generates(src: string, label: string) {
     println("---harn check stdout---")
     println(result.stdout)
   }
-  assert(result.success, "${label}: generated SDK must pass \\`harn check\\`")
+  require result.success, "${label}: generated SDK must pass \\`harn check\\`"
   let fmt_result = shell(harn_cmd("fmt --check " + tmp_path))
   if !fmt_result.success {
     println("---harn fmt --check stderr---")
@@ -79,7 +79,7 @@ fn check_generates(src: string, label: string) {
     println("---harn fmt --check stdout---")
     println(fmt_result.stdout)
   }
-  assert(fmt_result.success, "${label}: generated SDK must pass \\`harn fmt --check\\`")
+  require fmt_result.success, "${label}: generated SDK must pass \\`harn fmt --check\\`"
 }
 
 fn run_generated(src: string, label: string, imports: string, body: string) {
@@ -99,11 +99,11 @@ fn run_generated(src: string, label: string, imports: string, body: string) {
     println("---${label} runtime stdout---")
     println(result.stdout)
   }
-  assert(result.success, "${label}: generated SDK runtime auth assertions must pass")
+  require result.success, "${label}: generated SDK runtime auth assertions must pass"
 }
 
 @test
-pipeline default() {
+pipeline test_main() {
   // ------------------------------------------------------------------
   // Scenario A: http bearer at the doc level, inherited by all ops.
   // ------------------------------------------------------------------
@@ -113,12 +113,12 @@ pipeline default() {
     [{operation_id: "get-self", method: "get", path: "/v1/users/me"}],
   )
   let src_a = codegen_module(parse(doc_a), {module_name: "a", client_name: "A"})
-  assert_contains(src_a, "_headers_bearerauth(client)", "A/dispatch")
-  assert_contains(src_a, "Authorization: \"Bearer \" + _client_token(client)", "A/bearer-helper")
-  assert_contains(src_a, "token: string = \"\"", "A/client-has-token")
-  assert_contains(src_a, "token_provider = nil", "A/client-has-token-provider")
-  assert_not_contains(src_a, "basic_user: string", "A/no-basic-field")
-  assert_not_contains(src_a, "api_keys: dict", "A/no-apikey-field")
+  require_contains(src_a, "_headers_bearerauth(client)", "A/dispatch")
+  require_contains(src_a, "Authorization: \"Bearer \" + _client_token(client)", "A/bearer-helper")
+  require_contains(src_a, "token: string = \"\"", "A/client-has-token")
+  require_contains(src_a, "token_provider = nil", "A/client-has-token-provider")
+  require_not_contains(src_a, "basic_user: string", "A/no-basic-field")
+  require_not_contains(src_a, "api_keys: dict", "A/no-apikey-field")
   check_generates(src_a, "A")
   run_generated(
     src_a,
@@ -146,7 +146,7 @@ pipeline default() {
   )
   let src_b = codegen_module(parse(doc_b), {module_name: "b", client_name: "B"})
   // Authed op still uses the bearer helper.
-  assert_contains(src_b, "_headers_bearerauth(client)", "B/authed-dispatch")
+  require_contains(src_b, "_headers_bearerauth(client)", "B/authed-dispatch")
   // The no-auth op must route through _no_auth_headers.
   let b_lines = split(src_b, "\n")
   var b_public_line = ""
@@ -196,12 +196,12 @@ pipeline default() {
     [{operation_id: "login", method: "post", path: "/login"}],
   )
   let src_c = codegen_module(parse(doc_c), {module_name: "c", client_name: "C"})
-  assert_contains(src_c, "_headers_basicauth(client)", "C/dispatch")
-  assert_contains(src_c, "base64_encode", "C/basic-uses-base64")
-  assert_contains(src_c, "Authorization: \"Basic \" + encoded", "C/basic-header")
-  assert_contains(src_c, "basic_user: string = \"\"", "C/client-has-basic-user")
-  assert_contains(src_c, "basic_password: string = \"\"", "C/client-has-basic-password")
-  assert_not_contains(src_c, "token: string", "C/no-token-field")
+  require_contains(src_c, "_headers_basicauth(client)", "C/dispatch")
+  require_contains(src_c, "base64_encode", "C/basic-uses-base64")
+  require_contains(src_c, "Authorization: \"Basic \" + encoded", "C/basic-header")
+  require_contains(src_c, "basic_user: string = \"\"", "C/client-has-basic-user")
+  require_contains(src_c, "basic_password: string = \"\"", "C/client-has-basic-password")
+  require_not_contains(src_c, "token: string", "C/no-token-field")
   check_generates(src_c, "C")
   run_generated(
     src_c,
@@ -225,12 +225,12 @@ pipeline default() {
     [{operation_id: "get-thing", method: "get", path: "/thing"}],
   )
   let src_d = codegen_module(parse(doc_d), {module_name: "d", client_name: "D"})
-  assert_contains(src_d, "_headers_xapikey(client)", "D/dispatch")
-  assert_contains(src_d, "\"X-Api-Key\":", "D/header-name-emitted")
-  assert_contains(src_d, "_client_api_key(client, \"xApiKey\")", "D/reads-from-api-keys")
-  assert_contains(src_d, "api_keys: dict = {}", "D/client-has-api-keys")
-  assert_contains(src_d, "api_key_provider = nil", "D/client-has-api-key-provider")
-  assert_not_contains(src_d, "token: string", "D/no-token-field")
+  require_contains(src_d, "_headers_xapikey(client)", "D/dispatch")
+  require_contains(src_d, "\"X-Api-Key\":", "D/header-name-emitted")
+  require_contains(src_d, "_client_api_key(client, \"xApiKey\")", "D/reads-from-api-keys")
+  require_contains(src_d, "api_keys: dict = {}", "D/client-has-api-keys")
+  require_contains(src_d, "api_key_provider = nil", "D/client-has-api-key-provider")
+  require_not_contains(src_d, "token: string", "D/no-token-field")
   check_generates(src_d, "D")
   run_generated(
     src_d,
@@ -254,10 +254,10 @@ pipeline default() {
     [{operation_id: "list-things", method: "get", path: "/things"}],
   )
   let src_e = codegen_module(parse(doc_e), {module_name: "e", client_name: "E"})
-  assert_contains(src_e, "_headers_qkey(client)", "E/headers-dispatch")
-  assert_contains(src_e, "_query_qkey_dict(client)", "E/query-spread-in-op")
-  assert_contains(src_e, "api_key: v", "E/query-name-emitted")
-  assert_contains(src_e, "_query_string", "E/op-has-query-string-call")
+  require_contains(src_e, "_headers_qkey(client)", "E/headers-dispatch")
+  require_contains(src_e, "_query_qkey_dict(client)", "E/query-spread-in-op")
+  require_contains(src_e, "api_key: v", "E/query-name-emitted")
+  require_contains(src_e, "_query_string", "E/op-has-query-string-call")
   check_generates(src_e, "E")
   run_generated(
     src_e,
@@ -281,9 +281,9 @@ pipeline default() {
     [{operation_id: "me", method: "get", path: "/me"}],
   )
   let src_f = codegen_module(parse(doc_f), {module_name: "f", client_name: "F"})
-  assert_contains(src_f, "_headers_sessid(client)", "F/dispatch")
-  assert_contains(src_f, "Cookie: \"sid=\" +", "F/cookie-header")
-  assert_contains(src_f, "_client_api_key(client, \"sessId\")", "F/reads-from-api-keys")
+  require_contains(src_f, "_headers_sessid(client)", "F/dispatch")
+  require_contains(src_f, "Cookie: \"sid=\" +", "F/cookie-header")
+  require_contains(src_f, "_client_api_key(client, \"sessId\")", "F/reads-from-api-keys")
   check_generates(src_f, "F")
   run_generated(
     src_f,
@@ -312,10 +312,10 @@ pipeline default() {
     [{operation_id: "do-thing", method: "get", path: "/thing"}],
   )
   let src_g = codegen_module(parse(doc_g), {module_name: "g", client_name: "G"})
-  assert_contains(src_g, "_headers_oauth2auth(client)", "G/dispatch")
-  assert_contains(src_g, "Authorization: \"Bearer \" + _client_token(client)", "G/bearer-shape")
-  assert_contains(src_g, "token: string = \"\"", "G/client-has-token")
-  assert_contains(src_g, "token_provider = nil", "G/client-has-token-provider")
+  require_contains(src_g, "_headers_oauth2auth(client)", "G/dispatch")
+  require_contains(src_g, "Authorization: \"Bearer \" + _client_token(client)", "G/bearer-shape")
+  require_contains(src_g, "token: string = \"\"", "G/client-has-token")
+  require_contains(src_g, "token_provider = nil", "G/client-has-token-provider")
   check_generates(src_g, "G")
   run_generated(
     src_g,
@@ -349,8 +349,8 @@ pipeline default() {
   )
   let src_h = codegen_module(parse(doc_h), {module_name: "h", client_name: "H"})
   // Bearer helper defined and used by the default op.
-  assert_contains(src_h, "fn _headers_bearerauth(", "H/bearer-helper-defined")
-  assert_contains(src_h, "fn _headers_basicauth(", "H/basic-helper-defined")
+  require_contains(src_h, "fn _headers_bearerauth(", "H/bearer-helper-defined")
+  require_contains(src_h, "fn _headers_basicauth(", "H/basic-helper-defined")
   // Check per-op dispatch line by line.
   let h_lines = split(src_h, "\n")
   var h_get_me_line = ""
@@ -395,9 +395,9 @@ pipeline default() {
     [{operation_id: "mtls-op", method: "get", path: "/secure"}],
   )
   let src_i = codegen_module(parse(doc_i), {module_name: "i", client_name: "I"})
-  assert_contains(src_i, "// NOTE: security scheme 'mtls'", "I/fallback-note-emitted")
-  assert_contains(src_i, "_headers_mtls(client)", "I/fallback-helper-called")
-  assert_contains(src_i, "return _no_auth_headers(client)", "I/falls-back-to-no-auth")
+  require_contains(src_i, "// NOTE: security scheme 'mtls'", "I/fallback-note-emitted")
+  require_contains(src_i, "_headers_mtls(client)", "I/fallback-helper-called")
+  require_contains(src_i, "return _no_auth_headers(client)", "I/falls-back-to-no-auth")
   check_generates(src_i, "I")
   // ------------------------------------------------------------------
   // Scenario J: multiple security alternatives are preserved as a NOTE,
@@ -409,12 +409,12 @@ pipeline default() {
     [{operation_id: "either-auth", method: "get", path: "/either"}],
   )
   let src_j = codegen_module(parse(doc_j), {module_name: "j", client_name: "J"})
-  assert_contains(
+  require_contains(
     src_j,
     "NOTE: security alternatives also accepted: basicAuth",
     "J/security-alternative-note",
   )
-  assert_not_contains(src_j, "TODO", "J/generated-source-has-no-todos")
+  require_not_contains(src_j, "TODO", "J/generated-source-has-no-todos")
   check_generates(src_j, "J")
   println("security_smoke: ok")
 }

--- a/tests/types_smoke.harn
+++ b/tests/types_smoke.harn
@@ -2,29 +2,32 @@
 import "../src/lib"
 
 @test
-pipeline default() {
+pipeline test_main() {
   let raw = read_file(source_dir() + "/fixtures/notion.openapi.json")
   let doc: OpenApiDoc = parse(raw)
-  require is_openapi_doc(doc), "parse(raw) should satisfy the OpenApiDoc guard"
+  assert(is_openapi_doc(doc), "parse(raw) should satisfy the OpenApiDoc guard")
   let ops: list<Operation> = operations(doc)
-  require len(ops) > 40, "expected >40 typed operations"
-  require ops[0].method != nil, "typed operation should expose method"
-  require ops[0].path != nil, "typed operation should expose path"
-  require ops[0].operation_id != nil, "typed operation should expose operation_id"
+  assert(len(ops) > 40, "expected >40 typed operations")
+  assert(ops[0].method != nil, "typed operation should expose method")
+  assert(ops[0].path != nil, "typed operation should expose path")
+  assert(ops[0].operation_id != nil, "typed operation should expose operation_id")
   let ref_with_sibling = {"$ref": "#/components/schemas/annotationResponse", description: "sibling description"}
-  require is_reference(ref_with_sibling), "is_reference should detect $ref dicts"
+  assert(is_reference(ref_with_sibling), "is_reference should detect $ref dicts")
   let resolved: Schema = schema(doc, ref_with_sibling)
-  require resolved.get("$ref") == nil, "schema() should resolve the control $ref keyword away"
-  require resolved.description == "sibling description", "schema() should preserve non-$ref siblings"
+  assert(resolved.get("$ref") == nil, "schema() should resolve the control $ref keyword away")
+  assert(resolved.description == "sibling description", "schema() should preserve non-$ref siblings")
   let enum_schema: Schema = {type: "string", enum: ["a", "b"]}
   let values = enum_values(enum_schema)
-  require values != nil && len(values) == 2, "enum_values should preserve typed enum lists"
+  assert(values != nil && len(values) == 2, "enum_values should preserve typed enum lists")
   let synthetic = parse(read_file(source_dir() + "/fixtures/connector_helpers.openapi.json"))
   let helpers: list<AuthHelper> = auth_helpers(synthetic)
-  require helpers[0].scheme_name != nil, "AuthHelper should expose scheme_name"
+  assert(helpers[0].scheme_name != nil, "AuthHelper should expose scheme_name")
   let pages: list<PaginationPlan> = pagination_plans(synthetic)
-  require pages[0].operation_id != nil, "PaginationPlan should expose operation_id"
+  assert(pages[0].operation_id != nil, "PaginationPlan should expose operation_id")
   let rates: list<RateLimitMetadata> = rate_limit_metadata(synthetic)
-  require rates[0].retry_after_header == "Retry-After", "RateLimitMetadata should expose retry headers"
+  assert(
+    rates[0].retry_after_header == "Retry-After",
+    "RateLimitMetadata should expose retry headers",
+  )
   println("types_smoke: ok")
 }

--- a/tests/walk_smoke.harn
+++ b/tests/walk_smoke.harn
@@ -3,7 +3,7 @@
 // exercise enum_values() on a known enum schema.
 import { enum_values, operations, parse, schema } from "../src/lib"
 
-pipeline default() {
+pipeline test_main() {
   let raw = read_file(source_dir() + "/fixtures/notion.openapi.json")
   let doc = parse(raw)
   let ops = operations(doc)

--- a/tests/webhook_smoke.harn
+++ b/tests/webhook_smoke.harn
@@ -5,7 +5,7 @@
 // Tracks burin-labs/harn-openapi#2.
 import { component_path_items, parse, schema, webhook_operations } from "../src/lib"
 
-pipeline default() {
+pipeline test_main() {
   let raw = read_file(source_dir() + "/fixtures/notion.openapi.json")
   let doc = parse(raw)
   // parse() must surface the webhooks map.


### PR DESCRIPTION
## Summary

Three pre-existing lint gaps were fanning out across every regen and every test run. Now silent.

### 1. Generated SDK output is now lint-clean

Previously every regen (e.g. `harn lint /tmp/harn-openapi-regen-demo.harn`) emitted ~24 lint warnings. Fixes:

- Add `/** ... */` doc comments in `_MODULE_TEMPLATE` for `pagination_plan`, `pagination_items`, `pagination_next`, `rate_limit_from_response`, `is_rate_limited_response`.
- Add `/** Build a "<tag>" variant of the polymorphic request body. */` to body-variant constructors emitted by `_render_body_variant_constructor`.
- Replace `has_more == false` with `!has_more` in the cursor pagination branch (silences `lint[comparison-to-bool]`).

After: `harn lint /tmp/harn-openapi-regen-demo.harn` → no issues found.

### 2. Tests now register as test pipelines

The lint rule `assert-outside-test` keys off pipeline name (`test` or `test_*`), not the `@test` annotation. Every test in this repo used `pipeline default()`, so 110 stray warnings fired on every `harn lint tests` run. Renames each entry point to `pipeline test_main()`. `harn run tests/<file>.harn` still picks it up — there's only one pipeline per file.

### 3. `assert` ↔ `require` audit

The companion lint `require-in-test` fires when `require` is used inside a test pipeline body. So the right discipline is:
- **Inside test pipelines** (`pipeline test_main()` body): use `assert` / `assert_eq` / `assert_ne`.
- **Inside helper `fn`s** called from tests: use `require ..., "msg"`.

Audited every assertion call site and converted to match. Helper fns named `assert_contains` / `assert_not_contains` are renamed to `require_contains` / `require_not_contains` to advertise their throw mechanism.

## Test plan

- [x] `harn check src scripts tests` → exit 0
- [x] `harn lint src scripts tests` → exit 0, **no warnings** (was 110)
- [x] `harn fmt --check src scripts tests` → exit 0
- [x] All 14 tests pass (`tests/*.harn`)
- [x] `scripts/regen_demo.harn` regenerates the Notion SDK; `harn lint` on the output → no issues found