### PR TITLE
Polish OpenAPI codegen and package smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,12 +86,7 @@ jobs:
 
       - name: Run smoke tests
         run: |
-          set -euo pipefail
-          for test in tests/*.harn; do
-            echo "::group::$(basename "$test")"
-            "$HARN_BIN" run "$test"
-            echo "::endgroup::"
-          done
+          "$HARN_BIN" test tests --parallel --timing
         working-directory: harn-openapi
 
       - name: Run regen demo

--- a/README.md
+++ b/README.md
@@ -200,6 +200,10 @@ header. A single OpenAPI security requirement object is treated as an AND:
 `security: [{bearerAuth: [], apiKeyAuth: []}]` sends both schemes, while
 separate objects remain alternatives.
 
+Generated auth helpers omit missing bearer/basic/header/cookie credentials
+instead of sending malformed empty auth material. Cookie auth values use the
+same URL encoding path as normal cookie parameters.
+
 `new_client` takes only the client fields implied by the schemes in use,
 all defaulted so callers only supply what their spec actually needs:
 
@@ -302,7 +306,7 @@ released binary:
 harn check src scripts
 harn lint src scripts
 harn fmt --check src scripts tests
-for test in tests/*.harn; do HARN_BIN="$(command -v harn)" harn run "$test" || exit 1; done
+HARN_BIN="$(command -v harn)" harn test tests --parallel --timing
 harn run scripts/regen_demo.harn
 HARN_BIN="$(command -v harn)" harn run scripts/package_install_smoke.harn
 ```
@@ -314,7 +318,7 @@ cd ../harn
 cargo run --quiet --bin harn -- check ../harn-openapi/src ../harn-openapi/scripts
 cargo run --quiet --bin harn -- lint ../harn-openapi/src ../harn-openapi/scripts
 cargo run --quiet --bin harn -- fmt --check ../harn-openapi/src ../harn-openapi/scripts ../harn-openapi/tests
-for test in ../harn-openapi/tests/*.harn; do HARN_BIN="$PWD/target/debug/harn" cargo run --quiet --bin harn -- run "$test" || exit 1; done
+HARN_BIN="$PWD/target/debug/harn" cargo run --quiet --bin harn -- test ../harn-openapi/tests --parallel --timing
 HARN_BIN="$PWD/target/debug/harn" cargo run --quiet --bin harn -- run ../harn-openapi/scripts/regen_demo.harn
 HARN_BIN="$PWD/target/debug/harn" cargo run --quiet --bin harn -- run ../harn-openapi/scripts/package_install_smoke.harn
 ```

--- a/docs/migration-v0.1.0.md
+++ b/docs/migration-v0.1.0.md
@@ -19,9 +19,26 @@ Then import through the package export path:
 import { codegen_module, operations, parse } from "harn-openapi/default"
 ```
 
+The `types` export is intended for side-effect import when consumers want type
+aliases in scope:
+
+```harn
+import "harn-openapi/types"
+```
+
 Do not require a sibling `../harn-openapi` checkout in CI or in fresh-clone
 bootstrap docs. CI should install the pinned `harn-cli` from crates.io and let
 Harn resolve package dependencies from `harn.toml`.
+
+## Generated SDK names
+
+Generated operation functions use `snake_case` identifiers. OpenAPI ids such
+as `getPage`, `get-page`, and `get page` all map to `get_page` with numeric
+suffixes added only when two operations collide after normalization.
+
+If a pre-release generated SDK committed lowercased camelCase names such as
+`getpage`, regenerate it with the v0.1.0 codegen output and update callers to
+the `snake_case` names.
 
 ## Local override
 

--- a/scripts/package_install_smoke.harn
+++ b/scripts/package_install_smoke.harn
@@ -63,15 +63,21 @@ version = "0.0.0"
     "add harn-openapi dependency",
     _sh_quote(harn_bin) + " add " + _sh_quote(package_ref),
   )
+  _run(
+    smoke_root,
+    "locked offline install",
+    _sh_quote(harn_bin) + " install --locked --offline --json",
+  )
   write_file(
     smoke_root + "/smoke.harn",
     """
 import { operations, parse } from "harn-openapi/default"
+import "harn-openapi/types"
 
 pipeline default() {
   let raw = "{\"openapi\":\"3.1.0\",\"info\":{\"title\":\"Package Smoke\",\"version\":\"0.0.0\"},\"paths\":{\"/ping\":{\"get\":{\"operationId\":\"ping\",\"responses\":{\"200\":{\"description\":\"ok\"}}}}}}"
-  let doc = parse(raw)
-  let ops = operations(doc)
+  let doc: OpenApiDoc = parse(raw)
+  let ops: list<Operation> = operations(doc)
   require len(ops) == 1, "package import should parse and walk one operation"
   require ops[0].operation_id == "ping", "operation id should round-trip"
   println("package_install_smoke consumer: ok")

--- a/src/lib.harn
+++ b/src/lib.harn
@@ -57,6 +57,9 @@
 //   codegen_module(doc, options) -> string
 //       Emit a complete typed Harn SDK module source string. Options:
 //       { module_name, client_name, default_base_url?, header_overrides? }.
+//       Uses Harn's stdlib `render_string` template engine so generated-code
+//       rendering stays aligned with the runtime instead of a local template
+//       parser.
 //       The generated client handles per-operation security: a helper
 //       `_headers_<scheme>(client)` is emitted for each scheme declared
 //       in `components.securitySchemes` and actually referenced by at
@@ -994,6 +997,14 @@ let _MODULE_TEMPLATE = """
     return out
   }
 
+  fn _with_extra_headers(headers: dict, client: dict) -> dict {
+    var hs = headers
+    for entry in client.extra_headers {
+      hs = {...hs, [entry.key]: entry.value}
+    }
+    return hs
+  }
+
   fn _append_cookie_header(headers: dict, name: string, value) -> dict {
     if value == nil {
       return headers
@@ -1051,7 +1062,11 @@ let _MODULE_TEMPLATE = """
   fn _client_basic(client: dict) -> dict {
     let provider = client.get("basic_provider")
     if provider != nil {
-      return provider()
+      let provided = provider()
+      if type_of(provided) == "dict" {
+        return {user: provided.get("user") ?? "", password: provided.get("password") ?? ""}
+      }
+      return {user: "", password: ""}
     }
     return {user: client.get("basic_user") ?? "", password: client.get("basic_password") ?? ""}
   }
@@ -1565,76 +1580,61 @@ fn _render_auth_helper(scheme_name, def, fn_name, query_fn_name) {
   let kind = _scheme_kind(def)
   if kind == "bearer" || kind == "oauth2" || kind == "openIdConnect" {
     return "fn " + fn_name + "(client: dict) -> dict {\n"
+      + "  let token = _client_token(client)\n"
       + "  var hs = "
-      + _render_binding_dict(
-      [
-        "Authorization: \"Bearer \" + _client_token(client)",
-        _harn_dict_entry("Content-Type", "\"application/json\""),
-      ],
-    )
+      + _render_binding_dict([_harn_dict_entry("Content-Type", "\"application/json\"")])
       + "\n"
-      + "  for entry in client.extra_headers {\n"
-      + "    hs = {...hs, [entry.key]: entry.value}\n"
+      + "  if token != \"\" {\n"
+      + "    hs = {...hs, Authorization: \"Bearer \" + token}\n"
       + "  }\n"
-      + "  return hs\n"
+      + "  return _with_extra_headers(hs, client)\n"
       + "}"
   }
   if kind == "basic" {
     return "fn " + fn_name + "(client: dict) -> dict {\n"
       + "  let basic = _client_basic(client)\n"
-      + "  let encoded = base64_encode(to_string(basic.user) + \":\" + to_string(basic.password))\n"
       + "  var hs = "
-      + _render_binding_dict(
-      ["Authorization: \"Basic \" + encoded", _harn_dict_entry("Content-Type", "\"application/json\"")],
-    )
+      + _render_binding_dict([_harn_dict_entry("Content-Type", "\"application/json\"")])
       + "\n"
-      + "  for entry in client.extra_headers {\n"
-      + "    hs = {...hs, [entry.key]: entry.value}\n"
+      + "  if basic.get(\"user\") != \"\" || basic.get(\"password\") != \"\" {\n"
+      + "    let encoded = base64_encode(to_string(basic.user) + \":\" + to_string(basic.password))\n"
+      + "    hs = {...hs, Authorization: \"Basic \" + encoded}\n"
       + "  }\n"
-      + "  return hs\n"
+      + "  return _with_extra_headers(hs, client)\n"
       + "}"
   }
   if kind == "apiKey-header" {
     let header_name = def.get("name") ?? scheme_name
     return "fn " + fn_name + "(client: dict) -> dict {\n"
+      + "  let api_key = _client_api_key(client, \""
+      + _escape_string(scheme_name)
+      + "\")\n"
       + "  var hs = "
-      + _render_binding_dict(
-      [
-        _harn_dict_entry(
-          header_name,
-          "_client_api_key(client, \""
-            + _escape_string(scheme_name)
-            + "\")",
-        ),
-        _harn_dict_entry("Content-Type", "\"application/json\""),
-      ],
-    )
+      + _render_binding_dict([_harn_dict_entry("Content-Type", "\"application/json\"")])
       + "\n"
-      + "  for entry in client.extra_headers {\n"
-      + "    hs = {...hs, [entry.key]: entry.value}\n"
+      + "  if api_key != \"\" {\n"
+      + "    hs = {...hs, "
+      + _harn_dict_entry(header_name, "api_key")
+      + "}\n"
       + "  }\n"
-      + "  return hs\n"
+      + "  return _with_extra_headers(hs, client)\n"
       + "}"
   }
   if kind == "apiKey-cookie" {
     let cookie_name = def.get("name") ?? scheme_name
     return "fn " + fn_name + "(client: dict) -> dict {\n"
+      + "  let api_key = _client_api_key(client, \""
+      + _escape_string(scheme_name)
+      + "\")\n"
       + "  var hs = "
-      + _render_binding_dict(
-      [
-        "Cookie: \""
-          + _escape_string(cookie_name)
-          + "=\" + _client_api_key(client, \""
-          + _escape_string(scheme_name)
-          + "\")",
-        _harn_dict_entry("Content-Type", "\"application/json\""),
-      ],
-    )
+      + _render_binding_dict([_harn_dict_entry("Content-Type", "\"application/json\"")])
       + "\n"
-      + "  for entry in client.extra_headers {\n"
-      + "    hs = {...hs, [entry.key]: entry.value}\n"
+      + "  if api_key != \"\" {\n"
+      + "    hs = _append_cookie_header(hs, \""
+      + _escape_string(cookie_name)
+      + "\", api_key)\n"
       + "  }\n"
-      + "  return hs\n"
+      + "  return _with_extra_headers(hs, client)\n"
       + "}"
   }
   if kind == "apiKey-query" {
@@ -1646,10 +1646,7 @@ fn _render_auth_helper(scheme_name, def, fn_name, query_fn_name) {
       + "  var hs = "
       + _render_binding_dict([_harn_dict_entry("Content-Type", "\"application/json\"")])
       + "\n"
-      + "  for entry in client.extra_headers {\n"
-      + "    hs = {...hs, [entry.key]: entry.value}\n"
-      + "  }\n"
-      + "  return hs\n"
+      + "  return _with_extra_headers(hs, client)\n"
       + "}\n"
       + "\n"
       + "fn "
@@ -2534,6 +2531,22 @@ fn _media_type_without_parameters(raw) {
   return trim(lowered)
 }
 
+fn _index_of(hay, needle) {
+  let nh = len(hay)
+  let nn = len(needle)
+  if nn == 0 {
+    return 0
+  }
+  var i = 0
+  while i + nn <= nh {
+    if substring(hay, i, nn) == needle {
+      return i
+    }
+    i = i + 1
+  }
+  return -1
+}
+
 fn _is_success_code(code) {
   if type_of(code) != "string" {
     return false
@@ -2754,21 +2767,7 @@ fn _struct_has_renderable_keys(resolved) {
 }
 
 fn _sanitize_fn_name(raw) {
-  if raw == nil || raw == "" {
-    return "op"
-  }
-  let s1 = regex_replace_all("[^a-zA-Z0-9]+", "_", raw)
-  let s2 = regex_replace_all("^_+|_+$", "", s1)
-  let s3 = regex_replace_all("_+", "_", s2)
-  let lower = s3.lower()
-  if lower == "" {
-    return "op"
-  }
-  let first_char = substring(lower, 0, 1)
-  if _is_digit(first_char) {
-    return "op_" + lower
-  }
-  return lower
+  return _snake_case_base(raw, "op")
 }
 
 fn _sanitize_ident(raw) {
@@ -2780,8 +2779,16 @@ fn _sanitize_ident(raw) {
 }
 
 fn _snake_case_ident(raw) {
+  let out = _snake_case_base(raw, "variant")
+  if _is_reserved(out) {
+    return out + "_"
+  }
+  return out
+}
+
+fn _snake_case_base(raw, fallback) {
   if raw == nil || raw == "" {
-    return "variant"
+    return fallback
   }
   let cleaned = regex_replace_all("[^a-zA-Z0-9]+", "_", raw)
   var out = ""
@@ -2802,14 +2809,11 @@ fn _snake_case_ident(raw) {
   }
   out = regex_replace_all("^_+|_+$", "", out)
   if out == "" {
-    return "variant"
+    return fallback
   }
   let first_char = substring(out, 0, 1)
   if _is_digit(first_char) {
-    out = "variant_" + out
-  }
-  if _is_reserved(out) {
-    return out + "_"
+    return fallback + "_" + out
   }
   return out
 }
@@ -2955,230 +2959,4 @@ fn _render_dict_literal(d) {
     return "{}"
   }
   return "{" + join(parts, ", ") + "}"
-}
-
-// -------------------------------------------------------------------------------------------------
-
-// Minimal template engine — the stdlib `render` helper reads from files
-// on disk, but we want the codegen template inline so the library stays
-// one-file-loadable. This engine supports the features we actually use:
-// {{ ident }}, {{ dotted.lookup }}, {{ for x in xs }}..{{ end }}, and
-// {{ if cond }}..{{ else if cond }}..{{ else }}..{{ end }}.
-
-// -------------------------------------------------------------------------------------------------
-
-/** Render a triple-quoted template string against a bindings dict. */
-pub fn render_string(template: string, bindings: dict) -> string {
-  let tokens = _tpl_tokenize(template)
-  let result = _tpl_render_block(tokens, 0, len(tokens), bindings)
-  return result.text
-}
-
-fn _tpl_tokenize(src) {
-  var tokens = []
-  var i = 0
-  let n = len(src)
-  var buf = ""
-  while i < n {
-    if i + 1 < n && substring(src, i, 2) == "{{" {
-      if buf != "" {
-        tokens = tokens + [{kind: "text", body: buf}]
-        buf = ""
-      }
-      let close = _find_close(src, i + 2)
-      let inner = trim(substring(src, i + 2, close - (i + 2)))
-      tokens = tokens + [_tpl_classify(inner)]
-      i = close + 2
-    } else {
-      buf = buf + substring(src, i, 1)
-      i = i + 1
-    }
-  }
-  if buf != "" {
-    tokens = tokens + [{kind: "text", body: buf}]
-  }
-  return tokens
-}
-
-fn _find_close(src, start) {
-  let n = len(src)
-  var i = start
-  while i + 1 < n {
-    if substring(src, i, 2) == "}}" {
-      return i
-    }
-    i = i + 1
-  }
-  throw "render_string: unterminated '{{' in template"
-}
-
-fn _tpl_classify(inner) {
-  if starts_with(inner, "for ") {
-    let rest = trim(substring(inner, 4))
-    let space = _index_of(rest, " in ")
-    if space < 0 {
-      throw "render_string: malformed 'for' directive: " + inner
-    }
-    let var_name = trim(substring(rest, 0, space))
-    let expr = trim(substring(rest, space + 4))
-    return {kind: "for_open", var_name: var_name, expr: expr}
-  }
-  if starts_with(inner, "if ") {
-    return {kind: "if_open", expr: trim(substring(inner, 3))}
-  }
-  if starts_with(inner, "else if ") {
-    return {kind: "elif_open", expr: trim(substring(inner, 8))}
-  }
-  if inner == "else" {
-    return {kind: "else_open", expr: ""}
-  }
-  if inner == "end" {
-    return {kind: "end", expr: ""}
-  }
-  return {kind: "expr", expr: inner}
-}
-
-fn _index_of(hay, needle) {
-  let nh = len(hay)
-  let nn = len(needle)
-  if nn == 0 {
-    return 0
-  }
-  var i = 0
-  while i + nn <= nh {
-    if substring(hay, i, nn) == needle {
-      return i
-    }
-    i = i + 1
-  }
-  return -1
-}
-
-fn _tpl_render_block(tokens, start, end, bindings) {
-  var out = ""
-  var i = start
-  while i < end {
-    let t = tokens[i]
-    let kind = t.kind
-    if kind == "text" {
-      out = out + t.body
-      i = i + 1
-    } else if kind == "expr" {
-      out = out + to_string(_tpl_eval(t.expr, bindings))
-      i = i + 1
-    } else if kind == "for_open" {
-      let close = _tpl_find_end(tokens, i + 1, end)
-      let seq = _tpl_eval(t.expr, bindings)
-      if type_of(seq) == "list" {
-        for item in seq {
-          let inner = _tpl_render_block(tokens, i + 1, close, {...bindings, [t.var_name]: item})
-          out = out + inner.text
-        }
-      }
-      i = close + 1
-    } else if kind == "if_open" {
-      let scan = _tpl_scan_if(tokens, i, end)
-      var taken = false
-      for branch in scan.branches {
-        if !taken {
-          let cond = if branch.kind == "else_open" {
-            true
-          } else {
-            _tpl_truthy(_tpl_eval(branch.expr, bindings))
-          }
-          if cond {
-            let inner = _tpl_render_block(tokens, branch.body_start, branch.body_end, bindings)
-            out = out + inner.text
-            taken = true
-          }
-        }
-      }
-      i = scan.end_index + 1
-    } else {
-      return {text: out, next: i}
-    }
-  }
-  return {text: out, next: i}
-}
-
-fn _tpl_find_end(tokens, start, end) {
-  var depth = 0
-  var i = start
-  while i < end {
-    let k = tokens[i].kind
-    if k == "for_open" || k == "if_open" {
-      depth = depth + 1
-    } else if k == "end" {
-      if depth == 0 {
-        return i
-      }
-      depth = depth - 1
-    }
-    i = i + 1
-  }
-  throw "render_string: missing {{ end }} for block"
-}
-
-fn _tpl_scan_if(tokens, start, end) {
-  var depth = 0
-  var branches = []
-  let head = tokens[start]
-  var current = {kind: head.kind, expr: head.expr, body_start: start + 1, body_end: start + 1}
-  var i = start + 1
-  while i < end {
-    let t = tokens[i]
-    let k = t.kind
-    if k == "for_open" || k == "if_open" {
-      depth = depth + 1
-    } else if k == "end" {
-      if depth == 0 {
-        current = {...current, body_end: i}
-        branches = branches + [current]
-        return {branches: branches, end_index: i}
-      }
-      depth = depth - 1
-    } else if depth == 0 && (k == "elif_open" || k == "else_open") {
-      current = {...current, body_end: i}
-      branches = branches + [current]
-      current = {kind: k, expr: t.expr, body_start: i + 1, body_end: i + 1}
-    }
-    i = i + 1
-  }
-  throw "render_string: missing {{ end }} for if-block"
-}
-
-fn _tpl_truthy(v) {
-  if v == nil {
-    return false
-  }
-  if type_of(v) == "bool" {
-    return v
-  }
-  if v == "" {
-    return false
-  }
-  if v == 0 {
-    return false
-  }
-  if type_of(v) == "list" && len(v) == 0 {
-    return false
-  }
-  return true
-}
-
-fn _tpl_eval(expr: string, bindings: dict) {
-  let path = split(trim(expr), ".")
-  if len(path) == 0 {
-    return nil
-  }
-  var node = bindings.get(path[0])
-  var i = 1
-  while i < len(path) {
-    if node == nil {
-      return nil
-    }
-    node = node.get(path[i])
-    i = i + 1
-  }
-  return node
 }

--- a/tests/render_string_smoke.harn
+++ b/tests/render_string_smoke.harn
@@ -1,14 +1,12 @@
-// render_string_smoke — direct coverage for the inline template engine
-// used by codegen_module. codegen_smoke exercises it indirectly; this
-// keeps the public helper covered on its own.
-import { render_string } from "../src/lib"
-
+// render_string_smoke — direct coverage for the stdlib inline template
+// engine used by codegen_module. codegen_smoke exercises it indirectly;
+// this keeps the package pinned to the runtime feature it depends on.
 pipeline test_main() {
   let template = """
     Hello {{ user.name }}
     {{ if show }}shown{{ else }}hidden{{ end }}
     {{ for item in items }}[{{ item.label }}={{ item.value }}]{{ end }}
-    {{ if missing }}bad{{ else if fallback }}fallback{{ else }}none{{ end }}
+    {{ if missing }}bad{{ elif fallback }}fallback{{ else }}none{{ end }}
     """
   let out = render_string(
     template,

--- a/tests/response_types_smoke.harn
+++ b/tests/response_types_smoke.harn
@@ -180,37 +180,35 @@ pipeline test_main() {
   assert(contains(src, "tags?: list"), "PageObject.tags must be optional list")
   assert(contains(src, "meta?: dict"), "PageObject.meta must be optional dict")
   // --- Acceptance 3: both operations sharing PageObject return the
-  // same typed alias. Existing codegen lowercases operation_id when it
-  // has no word separators (see `_sanitize_fn_name`), so
-  // `getPage` -> `getpage` etc. ---
+  // same typed alias and use idiomatic snake_case function names. ---
   assert(
-    contains(src, "pub fn getpage(client: dict, id) -> PageObject"),
-    "getpage must return PageObject",
+    contains(src, "pub fn get_page(client: dict, id) -> PageObject"),
+    "get_page must return PageObject",
   )
   assert(
-    contains(src, "pub fn getpagebyslug(client: dict, slug) -> PageObject"),
-    "getpagebyslug must return PageObject",
+    contains(src, "pub fn get_page_by_slug(client: dict, slug) -> PageObject"),
+    "get_page_by_slug must return PageObject",
   )
   // --- Acceptance 4: inline search response gets a synthesized alias
   // named after its operation. ---
   assert(
-    contains(src, "pub fn searchitems(client: dict) -> SearchItemsResponse"),
-    "searchitems must return SearchItemsResponse",
+    contains(src, "pub fn search_items(client: dict) -> SearchItemsResponse"),
+    "search_items must return SearchItemsResponse",
   )
   assert(contains(src, "has_more?: bool"), "inline alias must type optional has_more")
   assert(contains(src, "next_cursor?: string"), "inline alias must type optional next_cursor")
   assert(contains(src, "results?: list"), "inline alias must type optional results")
   // --- Acceptance 5: 204 No Content -> nil return type, no json_parse. ---
   assert(
-    contains(src, "pub fn deletepage(client: dict, id) -> nil"),
-    "deletepage (204) must return nil",
+    contains(src, "pub fn delete_page(client: dict, id) -> nil"),
+    "delete_page (204) must return nil",
   )
-  let delete_block_start = _count_occurrences(src, "pub fn deletepage")
-  assert(delete_block_start == 1, "deletepage must be emitted once")
+  let delete_block_start = _count_occurrences(src, "pub fn delete_page")
+  assert(delete_block_start == 1, "delete_page must be emitted once")
   // --- Acceptance 6: non-JSON success body -> untyped fallback dict,
   // no bogus alias emission. ---
   assert(
-    contains(src, "pub fn getrawbytes(client: dict) -> dict"),
+    contains(src, "pub fn get_raw_bytes(client: dict) -> dict"),
     "non-JSON response body must fall back to dict",
   )
   let raw_alias = _count_occurrences(src, "type GetRawBytesResponse")

--- a/tests/security_smoke.harn
+++ b/tests/security_smoke.harn
@@ -105,8 +105,8 @@ pipeline test_main() {
     [{operation_id: "get-self", method: "get", path: "/v1/users/me"}],
   )
   let src_a = codegen_module(parse(doc_a), {module_name: "a", client_name: "A"})
-  require_contains(src_a, "_headers_bearerauth(client)", "A/dispatch")
-  require_contains(src_a, "Authorization: \"Bearer \" + _client_token(client)", "A/bearer-helper")
+  require_contains(src_a, "_headers_bearer_auth(client)", "A/dispatch")
+  require_contains(src_a, "Authorization: \"Bearer \" + token", "A/bearer-helper")
   require_contains(src_a, "token: string = \"\"", "A/client-has-token")
   require_contains(src_a, "token_provider = nil", "A/client-has-token-provider")
   require_not_contains(src_a, "basic_user: string", "A/no-basic-field")
@@ -125,6 +125,19 @@ pipeline test_main() {
       assert_eq(call.headers.authorization, "Bearer bearer-token")
     """,
   )
+  run_generated(
+    src_a,
+    "A-empty-token",
+    "new_client, get_self",
+    """
+      http_mock_clear()
+      http_mock("GET", "https://api.example.com/v1/users/me", {status: 200, body: "{}", headers: {}})
+      let client = new_client("https://api.example.com")
+      get_self(client)
+      let call = http_mock_calls({include_sensitive: true})[0]
+      assert_eq(call.headers.get("authorization"), nil)
+    """,
+  )
   // ------------------------------------------------------------------
   // Scenario B: explicit security: [] on one op overrides doc default.
   // ------------------------------------------------------------------
@@ -138,7 +151,7 @@ pipeline test_main() {
   )
   let src_b = codegen_module(parse(doc_b), {module_name: "b", client_name: "B"})
   // Authed op still uses the bearer helper.
-  require_contains(src_b, "_headers_bearerauth(client)", "B/authed-dispatch")
+  require_contains(src_b, "_headers_bearer_auth(client)", "B/authed-dispatch")
   // The no-auth op must route through _no_auth_headers.
   let b_lines = split(src_b, "\n")
   var b_public_line = ""
@@ -159,7 +172,7 @@ pipeline test_main() {
     "B/public-op-must-use-no-auth-headers: got \"${b_public_line}\"",
   )
   assert(
-    !contains(b_public_line, "_headers_bearerauth"),
+    !contains(b_public_line, "_headers_bearer_auth"),
     "B/public-op-must-NOT-use-bearer-helper: got \"${b_public_line}\"",
   )
   check_generates(src_b, "B")
@@ -188,7 +201,7 @@ pipeline test_main() {
     [{operation_id: "login", method: "post", path: "/login"}],
   )
   let src_c = codegen_module(parse(doc_c), {module_name: "c", client_name: "C"})
-  require_contains(src_c, "_headers_basicauth(client)", "C/dispatch")
+  require_contains(src_c, "_headers_basic_auth(client)", "C/dispatch")
   require_contains(src_c, "base64_encode", "C/basic-uses-base64")
   require_contains(src_c, "Authorization: \"Basic \" + encoded", "C/basic-header")
   require_contains(src_c, "basic_user: string = \"\"", "C/client-has-basic-user")
@@ -217,7 +230,7 @@ pipeline test_main() {
     [{operation_id: "get-thing", method: "get", path: "/thing"}],
   )
   let src_d = codegen_module(parse(doc_d), {module_name: "d", client_name: "D"})
-  require_contains(src_d, "_headers_xapikey(client)", "D/dispatch")
+  require_contains(src_d, "_headers_x_api_key(client)", "D/dispatch")
   require_contains(src_d, "\"X-Api-Key\":", "D/header-name-emitted")
   require_contains(src_d, "_client_api_key(client, \"xApiKey\")", "D/reads-from-api-keys")
   require_contains(src_d, "api_keys: dict = {}", "D/client-has-api-keys")
@@ -246,8 +259,8 @@ pipeline test_main() {
     [{operation_id: "list-things", method: "get", path: "/things"}],
   )
   let src_e = codegen_module(parse(doc_e), {module_name: "e", client_name: "E"})
-  require_contains(src_e, "_headers_qkey(client)", "E/headers-dispatch")
-  require_contains(src_e, "_query_qkey_dict(client)", "E/query-spread-in-op")
+  require_contains(src_e, "_headers_q_key(client)", "E/headers-dispatch")
+  require_contains(src_e, "_query_q_key_dict(client)", "E/query-spread-in-op")
   require_contains(src_e, "api_key: v", "E/query-name-emitted")
   require_contains(src_e, "_query_string", "E/op-has-query-string-call")
   check_generates(src_e, "E")
@@ -273,8 +286,8 @@ pipeline test_main() {
     [{operation_id: "me", method: "get", path: "/me"}],
   )
   let src_f = codegen_module(parse(doc_f), {module_name: "f", client_name: "F"})
-  require_contains(src_f, "_headers_sessid(client)", "F/dispatch")
-  require_contains(src_f, "Cookie: \"sid=\" +", "F/cookie-header")
+  require_contains(src_f, "_headers_sess_id(client)", "F/dispatch")
+  require_contains(src_f, "_append_cookie_header(hs, \"sid\", api_key)", "F/cookie-header")
   require_contains(src_f, "_client_api_key(client, \"sessId\")", "F/reads-from-api-keys")
   check_generates(src_f, "F")
   run_generated(
@@ -284,10 +297,10 @@ pipeline test_main() {
     """
       http_mock_clear()
       http_mock("GET", "https://api.example.com/me", {status: 200, body: "{}", headers: {}})
-      let client = new_client("https://api.example.com", {sessId: "cookie-key"})
+      let client = new_client("https://api.example.com", {sessId: "cookie key;admin=true"})
       me(client)
       let call = http_mock_calls({include_sensitive: true})[0]
-      assert_eq(call.headers.cookie, "sid=cookie-key")
+      assert_eq(call.headers.cookie, "sid=cookie%20key%3Badmin%3Dtrue")
     """,
   )
   // ------------------------------------------------------------------
@@ -304,8 +317,8 @@ pipeline test_main() {
     [{operation_id: "do-thing", method: "get", path: "/thing"}],
   )
   let src_g = codegen_module(parse(doc_g), {module_name: "g", client_name: "G"})
-  require_contains(src_g, "_headers_oauth2auth(client)", "G/dispatch")
-  require_contains(src_g, "Authorization: \"Bearer \" + _client_token(client)", "G/bearer-shape")
+  require_contains(src_g, "_headers_oauth2_auth(client)", "G/dispatch")
+  require_contains(src_g, "Authorization: \"Bearer \" + token", "G/bearer-shape")
   require_contains(src_g, "token: string = \"\"", "G/client-has-token")
   require_contains(src_g, "token_provider = nil", "G/client-has-token-provider")
   check_generates(src_g, "G")
@@ -341,8 +354,8 @@ pipeline test_main() {
   )
   let src_h = codegen_module(parse(doc_h), {module_name: "h", client_name: "H"})
   // Bearer helper defined and used by the default op.
-  require_contains(src_h, "fn _headers_bearerauth(", "H/bearer-helper-defined")
-  require_contains(src_h, "fn _headers_basicauth(", "H/basic-helper-defined")
+  require_contains(src_h, "fn _headers_bearer_auth(", "H/bearer-helper-defined")
+  require_contains(src_h, "fn _headers_basic_auth(", "H/basic-helper-defined")
   // Check per-op dispatch line by line.
   let h_lines = split(src_h, "\n")
   var h_get_me_line = ""
@@ -366,15 +379,15 @@ pipeline test_main() {
     }
   }
   assert(
-    contains(h_get_me_line, "_headers_bearerauth(client)"),
+    contains(h_get_me_line, "_headers_bearer_auth(client)"),
     "H/get_me-uses-bearer: got \"${h_get_me_line}\"",
   )
   assert(
-    contains(h_token_line, "_headers_basicauth(client)"),
+    contains(h_token_line, "_headers_basic_auth(client)"),
     "H/create_a_token-uses-basic: got \"${h_token_line}\"",
   )
   assert(
-    !contains(h_token_line, "_headers_bearerauth"),
+    !contains(h_token_line, "_headers_bearer_auth"),
     "H/create_a_token-must-NOT-use-bearer: got \"${h_token_line}\"",
   )
   check_generates(src_h, "H")


### PR DESCRIPTION
## Summary
- remove the repo-local inline template parser and use Harn stdlib `render_string` for codegen
- harden generated auth helpers so empty credentials are omitted and cookie api keys are encoded through the shared cookie path
- switch generated operation names to `snake_case` for camelCase OpenAPI ids
- tighten package/CI smoke coverage with `harn test --parallel`, locked/offline install, and the `types` export

## Verification
- `harn check src scripts`
- `harn lint src scripts`
- `harn fmt --check src scripts tests`
- `HARN_BIN="$(command -v harn)" harn test tests --parallel --timing`
- `harn run scripts/regen_demo.harn`
- `HARN_BIN="$(command -v harn)" harn run scripts/package_install_smoke.harn`
- `harn run scripts/check_fixture_staleness.harn`
