### PR TITLE
Fix pagination metadata for body cursors

### DIFF
--- a/harn.toml
+++ b/harn.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 description = "Pure-Harn OpenAPI 3.1 parser and SDK codegen helpers."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/burin-labs/harn-openapi"
+docs_url = "https://github.com/burin-labs/harn-openapi#readme"
+harn = ">=0.8,<0.9"
 
 [exports]
 default = "src/lib.harn"

--- a/src/lib.harn
+++ b/src/lib.harn
@@ -371,10 +371,13 @@ type PaginationPlan = {
   kind: string,
   items_field?: string,
   cursor_param?: string,
+  cursor_location?: string,
   cursor_response_field?: string,
   has_more_field?: string,
   page_param?: string,
+  page_location?: string,
   page_size_param?: string,
+  page_size_location?: string,
   next_link_field?: string,
   link_header?: string,
 }
@@ -794,42 +797,51 @@ pub fn pagination_plans(doc: OpenApiDoc) -> list<PaginationPlan> {
 
 fn _pagination_plan_for_op(doc, op) {
   let params = op.parameters ?? []
-  let cursor_param = _first_param_named(params, ["start_cursor", "cursor", "after", "page_token", "next_page_token"])
-  let page_param = _first_param_named(params, ["page", "page_number", "page_index", "offset"])
-  let page_size_param = _first_param_named(params, ["page_size", "per_page", "limit", "size"])
+  let body_props = _request_body_json_properties(doc, op)
+  let cursor = _pagination_request_field(
+    params,
+    body_props,
+    ["start_cursor", "cursor", "after", "page_token", "next_page_token"],
+  )
+  let page = _pagination_request_field(params, body_props, ["page", "page_number", "page_index", "offset"])
+  let page_size = _pagination_request_field(params, body_props, ["page_size", "per_page", "limit", "size"])
   let picked = _pick_success_response(doc, op)
   if picked == nil || picked.kind != "json" {
     return nil
   }
   let full = schema(doc, picked.schema)
   let props = full.get("properties") ?? {}
-  let items_field = _first_present_key(props, ["results", "data", "items", "records", "objects"])
+  let items_field = _first_present_key(props, ["results", "templates", "data", "items", "records", "objects"])
   let next_cursor = _first_present_key(props, ["next_cursor", "next_page_token", "cursor", "after"])
   let has_more = _first_present_key(props, ["has_more", "hasMore", "more"])
   let next_link = _first_present_key(props, ["next", "next_url", "next_link", "nextPageUrl"])
   let link_header = _success_response_header(doc, op, "Link")
-  if cursor_param != nil && next_cursor != nil {
+  if cursor.name != nil && next_cursor != nil {
     return {
       operation_id: op.operation_id,
       method: op.method,
       path: op.path,
       kind: "cursor",
       items_field: items_field,
-      cursor_param: cursor_param,
+      cursor_param: cursor.name,
+      cursor_location: cursor.location,
       cursor_response_field: next_cursor,
       has_more_field: has_more,
-      page_size_param: page_size_param,
+      page_size_param: page_size.name,
+      page_size_location: page_size.location,
     }
   }
-  if page_param != nil {
+  if page.name != nil {
     return {
       operation_id: op.operation_id,
       method: op.method,
       path: op.path,
       kind: "page",
       items_field: items_field,
-      page_param: page_param,
-      page_size_param: page_size_param,
+      page_param: page.name,
+      page_location: page.location,
+      page_size_param: page_size.name,
+      page_size_location: page_size.location,
     }
   }
   if next_link != nil || link_header != nil {
@@ -844,6 +856,31 @@ fn _pagination_plan_for_op(doc, op) {
     }
   }
   return nil
+}
+
+fn _request_body_json_properties(doc, op) -> dict {
+  let request_schema = _request_json_schema(doc, op.request_body)
+  if request_schema == nil {
+    return {}
+  }
+  let full = schema(doc, request_schema)
+  let props = full.get("properties")
+  if type_of(props) == "dict" {
+    return props
+  }
+  return {}
+}
+
+fn _pagination_request_field(params, body_props, names) -> dict {
+  let query_field = _first_param_named(params, names)
+  if query_field != nil {
+    return {name: query_field, location: "query"}
+  }
+  let body_field = _first_present_key(body_props, names)
+  if body_field != nil {
+    return {name: body_field, location: "body"}
+  }
+  return {name: nil, location: nil}
 }
 
 fn _first_param_named(params, names) {
@@ -1104,7 +1141,7 @@ let _MODULE_TEMPLATE = """
 
   /**
    * Compute the next-page directive from `response` according to `plan`.
-   * Returns a dict with `done: bool` plus either a `query` dict to merge
+   * Returns a dict with `done: bool` plus a `query` or `body` dict to merge
    * into the next call, or a `url` to follow (next-link style).
    */
   pub fn pagination_next(response: dict, plan: dict) -> dict {
@@ -1122,7 +1159,11 @@ let _MODULE_TEMPLATE = """
       } else {
         response.get(has_more_field)
       }
-      return {done: cursor == nil || !has_more, query: {[plan.cursor_param]: cursor}}
+      let field = plan.get("cursor_param")
+      if plan.get("cursor_location") == "body" {
+        return {done: cursor == nil || !has_more, body: {[field]: cursor}}
+      }
+      return {done: cursor == nil || !has_more, query: {[field]: cursor}}
     }
     if kind == "page" {
       return {done: false, query: {}}

--- a/src/types.harn
+++ b/src/types.harn
@@ -292,10 +292,13 @@ type PaginationPlan = {
   kind: string,
   items_field?: string,
   cursor_param?: string,
+  cursor_location?: string,
   cursor_response_field?: string,
   has_more_field?: string,
   page_param?: string,
+  page_location?: string,
   page_size_param?: string,
+  page_size_location?: string,
   next_link_field?: string,
   link_header?: string,
 }

--- a/tests/connector_helpers_smoke.harn
+++ b/tests/connector_helpers_smoke.harn
@@ -90,8 +90,25 @@ pipeline test_main() {
   assert(cursor != nil, "listItems should have a cursor pagination plan")
   assert(cursor.kind == "cursor", "listItems should be cursor-pagination")
   assert(cursor.cursor_param == "start_cursor", "cursor plan should preserve request cursor param")
+  assert(cursor.cursor_location == "query", "cursor plan should preserve query cursor location")
   assert(cursor.cursor_response_field == "next_cursor", "cursor plan should preserve response cursor")
   assert(cursor.items_field == "results", "cursor plan should preserve items field")
+  let body_cursor = plan_by_id(plans, "listBodyItems")
+  assert(body_cursor != nil, "listBodyItems should have a body cursor pagination plan")
+  assert(body_cursor.kind == "cursor", "listBodyItems should be cursor-pagination")
+  assert(body_cursor.cursor_param == "start_cursor", "body cursor plan should preserve cursor field")
+  assert(body_cursor.cursor_location == "body", "body cursor plan should preserve cursor location")
+  assert(
+    body_cursor.page_size_param == "page_size",
+    "body cursor plan should preserve page size field",
+  )
+  assert(
+    body_cursor.page_size_location == "body",
+    "body cursor plan should preserve page size location",
+  )
+  let templates = plan_by_id(plans, "listTemplateItems")
+  assert(templates != nil, "listTemplateItems should have a cursor pagination plan")
+  assert(templates.items_field == "templates", "template list should preserve templates item field")
   let page = plan_by_id(plans, "listPageItems")
   assert(page != nil && page.kind == "page", "listPageItems should have a page plan")
   let next_link = plan_by_id(plans, "listNextLinkItems")
@@ -134,6 +151,18 @@ pipeline test_main() {
     src,
     "\\\"kind\\\":\\\"cursor\\\"",
     "generated cursor pagination metadata",
+  )
+  require_contains(
+    harness,
+    src,
+    "\\\"cursor_location\\\":\\\"body\\\"",
+    "generated body cursor pagination metadata",
+  )
+  require_contains(
+    harness,
+    src,
+    "\\\"items_field\\\":\\\"templates\\\"",
+    "generated templates pagination metadata",
   )
   require_contains(
     harness,

--- a/tests/fixtures/connector_helpers.openapi.json
+++ b/tests/fixtures/connector_helpers.openapi.json
@@ -79,6 +79,71 @@
         }
       }
     },
+    "/body-items": {
+      "post": {
+        "operationId": "listBodyItems",
+        "summary": "List items with body cursor",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "start_cursor": {
+                    "type": "string"
+                  },
+                  "page_size": {
+                    "type": "integer"
+                  },
+                  "filter": {
+                    "type": "object"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CursorPage"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/template-items": {
+      "get": {
+        "operationId": "listTemplateItems",
+        "summary": "List template items",
+        "parameters": [
+          {
+            "name": "start_cursor",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TemplatePage"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/page-items": {
       "get": {
         "operationId": "listPageItems",
@@ -256,6 +321,23 @@
           },
           "next_url": {
             "type": "string"
+          }
+        }
+      },
+      "TemplatePage": {
+        "type": "object",
+        "properties": {
+          "templates": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "next_cursor": {
+            "type": "string"
+          },
+          "has_more": {
+            "type": "boolean"
           }
         }
       }

--- a/tests/response_types_smoke.harn
+++ b/tests/response_types_smoke.harn
@@ -125,22 +125,10 @@ let _TINY_DOC = """
   """
 
 fn _count_occurrences(haystack: string, needle: string) -> int {
-  var count = 0
-  var idx = 0
-  let hn = len(haystack)
-  let nn = len(needle)
-  if nn == 0 {
+  if needle == "" {
     return 0
   }
-  while idx + nn <= hn {
-    if substring(haystack, idx, nn) == needle {
-      count = count + 1
-      idx = idx + nn
-    } else {
-      idx = idx + 1
-    }
-  }
-  return count
+  return len(split(haystack, needle)) - 1
 }
 
 pipeline test_main() {


### PR DESCRIPTION
## Summary

- Detect OpenAPI cursor/page/page_size fields from JSON request bodies as well as query parameters.
- Preserve pagination field location in generated metadata so body-cursor endpoints can be driven correctly.
- Treat `templates` arrays as list items and cover the behavior in connector helper fixtures.
- Add publish-readiness Harn compatibility metadata and speed up a response-type smoke helper.

## Validation

- `HARN_BIN=/Users/ksinder/projects/harn/target/debug/harn /Users/ksinder/projects/harn/target/debug/harn run tests/connector_helpers_smoke.harn`
- `HARN_BIN=/Users/ksinder/projects/harn/target/debug/harn for t in tests/*.harn; do /Users/ksinder/projects/harn/target/debug/harn run "$t"; done`
- `/Users/ksinder/projects/harn/target/debug/harn check src tests/connector_helpers_smoke.harn`
- `/Users/ksinder/projects/harn/target/debug/harn fmt --check src tests/connector_helpers_smoke.harn`
- `/Users/ksinder/projects/harn/target/debug/harn package check`
