### PR TITLE
[codex] Generate connector-policy OpenAPI transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ repo keeps that shared logic in one pure-Harn package:
 - generate typed Harn SDK source for downstream provider repos;
 - keep a pinned real-world Notion OpenAPI fixture for deterministic coverage.
 
+The generator is intentionally scoped to focused API packages backed by an
+OpenAPI document. Broad cloud SDK families, provider discovery formats, Smithy,
+and provider-specific auth flows belong in dedicated packages above this layer,
+not in `harn-openapi`.
+
 The repo intentionally has no Cargo workspace, `package.json`, generated build
 system, or non-Harn runtime dependency. CI and local development install the
 pinned Harn CLI from crates.io using `.harn-version`.
@@ -115,6 +120,8 @@ let limits = rate_limit_metadata(doc)
 let src = codegen_module(doc, {
   module_name: "notion",
   client_name: "Client",
+  // Optional. Defaults to raw http_get/post/... calls.
+  transport: "connector_policy",
 })
 write_file("./src/lib.harn", src)
 write_file(
@@ -170,7 +177,8 @@ import { parse } from "../src/lib"
   conventions for downstream retry/backoff code.
 - `codegen_module(doc: OpenApiDoc, options: dict) -> string` — emit a typed Harn SDK
   module source string with per-scheme security dispatch, credential-provider
-  hooks, pagination metadata, and rate-limit metadata (see below).
+  hooks, optional connector-policy transport, pagination metadata, and
+  rate-limit metadata (see below).
 - `codegen_harn_toml(options: dict) -> string` — emit a package manifest for a
   generated SDK repo with `[package]`, `[exports]`, and `[dependencies]`.
 
@@ -247,6 +255,38 @@ are merged into the request headers, and cookie parameters are appended to the
 
 Out of scope for v0: full OAuth2 flows (authorization-code, device,
 PKCE) and `mutualTLS` client-certificate plumbing.
+
+### Transport policy
+
+Generated SDKs default to the historical raw transport: direct `http_get`,
+`http_post`, and sibling calls with structured throws for non-2xx responses.
+That keeps existing generated packages stable until they opt in.
+
+For connector packages that want shared retry, idempotency, JSON parse, and
+rate-limit behavior, select the connector policy transport:
+
+```harn
+let src = codegen_module(doc, {
+  module_name: "example_sdk",
+  client_name: "ExampleClient",
+  transport: "connector_policy",
+})
+```
+
+Connector-policy output imports `connector_http_request` and
+`connector_http_json` from `std/connectors/shared`. JSON response operations
+call `connector_http_json`; opaque or empty-response operations call
+`connector_http_request`. On helper errors, generated functions throw the
+helper envelope directly, so callers can branch on `category`, `status`,
+`retryable`, `retry_after_ms`, `error`, and `rate_limit` without parsing a
+string.
+
+Safe or idempotent methods (`GET`, `HEAD`, `PUT`, `DELETE`, `OPTIONS`) emit a
+bounded retry policy. `POST` and `PATCH` emit that retry policy only when the
+OpenAPI operation declares an explicit `Idempotency-Key` header parameter; the
+generated function also threads that parameter into `options.idempotency_key`
+for the shared helper. Unsafe writes without an idempotency key emit
+`max_attempts: 1`, leaving retries disabled by default.
 
 ### Pagination and rate-limit helpers
 

--- a/src/lib.harn
+++ b/src/lib.harn
@@ -56,7 +56,10 @@
 //
 //   codegen_module(doc, options) -> string
 //       Emit a complete typed Harn SDK module source string. Options:
-//       { module_name, client_name, default_base_url?, header_overrides? }.
+//       { module_name, client_name, default_base_url?, header_overrides?,
+//       transport? }. `transport: "connector_policy"` emits calls through
+//       std/connectors/shared while the default raw transport keeps emitting
+//       direct `http_get` / `http_post` / ... calls.
 //       Uses Harn's stdlib `render_string` template engine so generated-code
 //       rendering stays aligned with the runtime instead of a local template
 //       parser.
@@ -391,20 +394,6 @@ type RateLimitMetadata = {
   limit_headers: list<string>,
   remaining_headers: list<string>,
   reset_headers: list<string>,
-}
-
-type ParseOpenApiDoc = {
-  openapi: string,
-  info: Info,
-  jsonSchemaDialect?: string,
-  servers?: list,
-  paths?: dict,
-  webhooks?: dict,
-  components?: dict,
-  security_schemes?: dict,
-  security?: list,
-  tags?: list,
-  externalDocs?: ExternalDocumentation,
 }
 
 let _OPENAPI_DOC_SCHEMA = {
@@ -1006,6 +995,9 @@ let _MODULE_TEMPLATE = """
    * Source doc: {{ doc_title }} (OpenAPI {{ openapi_version }})
    * Module:     {{ module_name }}
    */
+  {{ if connector_transport }}
+  import { connector_http_json, connector_http_request } from "std/connectors/shared"
+  {{ end }}
 
   {{ for alias in response_aliases }}
   {{ alias.source }}
@@ -1200,9 +1192,12 @@ let _MODULE_TEMPLATE = """
     return {
       status: resp.get("status"),
       retry_after: _header_ci(headers, "Retry-After"),
-      limit: _header_ci(headers, "X-RateLimit-Limit"),
-      remaining: _header_ci(headers, "X-RateLimit-Remaining"),
-      reset: _header_ci(headers, "X-RateLimit-Reset"),
+      limit: _header_ci(headers, "RateLimit-Limit")
+        ?? _header_ci(headers, "X-RateLimit-Limit"),
+      remaining: _header_ci(headers, "RateLimit-Remaining")
+        ?? _header_ci(headers, "X-RateLimit-Remaining"),
+      reset: _header_ci(headers, "RateLimit-Reset")
+        ?? _header_ci(headers, "X-RateLimit-Reset"),
     }
   }
 
@@ -1276,9 +1271,7 @@ let _MODULE_TEMPLATE = """
     var request_headers = {{ op.headers_call }}{{ if op.header_cookie_lines }}
     {{ op.header_cookie_lines }}{{ end }}
     {{ op.request_lines }}
-    if resp.status >= 400 {
-      {{ op.error_throw }}
-    }
+    {{ op.error_lines }}
     {{ op.return_lines }}
   }
   {{ op.body_variant_constructors }}
@@ -1291,6 +1284,7 @@ pub fn codegen_module(doc: OpenApiDoc, options: dict) -> string {
   let client_name = options.get("client_name") ?? "Client"
   let default_base_url = options.get("default_base_url") ?? _default_server_url(doc)
   let header_overrides = options.get("header_overrides") ?? {}
+  let transport = _transport_kind(options.get("transport") ?? "raw")
   let schemes = doc.get("security_schemes") ?? {}
   let doc_security = doc.get("security") ?? []
   let ops_raw = operations(doc)
@@ -1347,7 +1341,18 @@ pub fn codegen_module(doc: OpenApiDoc, options: dict) -> string {
     let op = entry.value
     let ret = op_return_types[entry.index]
     let choice = _resolve_security(op.security, doc_security)
-    let model = _build_op_model(doc, op, seen_names, choice, schemes, ret, helper_names, header_overrides)
+    let model = _build_op_model(
+      doc,
+      op,
+      seen_names,
+      choice,
+      schemes,
+      ret,
+      helper_names,
+      header_overrides,
+      transport,
+      module_name,
+    )
     seen_names = seen_names + [model.fn_name] + model.body_variant_fn_names
     ops = ops + [model]
   }
@@ -1364,6 +1369,7 @@ pub fn codegen_module(doc: OpenApiDoc, options: dict) -> string {
     new_client_decl: new_client_decl,
     new_client_return: _render_new_client_return(client_fields),
     client_fields: client_fields,
+    connector_transport: transport == "connector_policy",
     auth_helpers: auth_helpers,
     operations: ops,
     response_aliases: alias_entries,
@@ -1617,6 +1623,18 @@ fn _normalize_generated_source(src, module_name) {
   return out.trim() + "\n"
 }
 
+fn _transport_kind(value) {
+  let transport = to_string(value ?? "raw")
+  if transport == "raw" {
+    return "raw"
+  }
+  if transport == "connector_policy" {
+    return "connector_policy"
+  }
+  throw "harn-openapi.codegen_module: unsupported transport '" + transport
+    + "' (expected 'raw' or 'connector_policy')"
+}
+
 fn _render_auth_helper(scheme_name, def, fn_name, query_fn_name) {
   let kind = _scheme_kind(def)
   if kind == "bearer" || kind == "oauth2" || kind == "openIdConnect" {
@@ -1814,7 +1832,18 @@ fn _signature_model(
   }
 }
 
-fn _build_op_model(doc, op, taken_names, choice, schemes, ret, helper_names, header_overrides) {
+fn _build_op_model(
+  doc,
+  op,
+  taken_names,
+  choice,
+  schemes,
+  ret,
+  helper_names,
+  header_overrides,
+  transport,
+  module_name,
+) {
   let fn_name = _unique_fn_name(_sanitize_ident(op.operation_id), taken_names)
   let param_model = _operation_param_models(op.parameters)
   let path_params = param_model.path
@@ -1861,6 +1890,7 @@ fn _build_op_model(doc, op, taken_names, choice, schemes, ret, helper_names, hea
   }
   let body_variants = _body_variants_for_op(doc, op, fn_name, taken_names)
   let body_prepare = _render_body_prepare(fn_name, body_variants)
+  let idempotency_key_param = _idempotency_key_param(header_params)
   return {
     fn_name: fn_name,
     method: op.method,
@@ -1872,7 +1902,17 @@ fn _build_op_model(doc, op, taken_names, choice, schemes, ret, helper_names, hea
     has_body: has_body,
     body_prepare: body_prepare,
     header_cookie_lines: _render_header_cookie_lines(header_params, cookie_params),
-    request_lines: _render_request_lines(op.method, has_body, body_required, body_prepare),
+    request_lines: _render_request_lines(
+      op.method,
+      has_body,
+      body_required,
+      body_prepare,
+      transport,
+      ret,
+      fn_name,
+      module_name,
+      idempotency_key_param,
+    ),
     body_variant_constructors: _render_body_variant_constructors(body_variants),
     body_variant_fn_names: _body_variant_fn_names(body_variants),
     doc_comment: doc_comment,
@@ -1880,8 +1920,8 @@ fn _build_op_model(doc, op, taken_names, choice, schemes, ret, helper_names, hea
     security_note: security_note,
     return_type: ret.type_name,
     returns_nil: ret.returns_nil,
-    return_lines: _render_return_lines(fn_name, ret),
-    error_throw: _render_error_throw(fn_name),
+    return_lines: _render_return_lines(fn_name, ret, transport),
+    error_lines: _render_error_lines(fn_name, transport),
   }
 }
 
@@ -1906,6 +1946,19 @@ fn _render_error_throw(fn_name) {
     + "      body: resp.body,\n"
     + "      headers: resp.headers,\n"
     + "    }"
+}
+
+fn _render_error_lines(fn_name, transport) {
+  if transport == "connector_policy" {
+    return "if !(resp.ok ?? false) {\n"
+      + "    throw resp\n"
+      + "  }"
+  }
+  return "if resp.status >= 400 {\n"
+    + "    "
+    + _render_error_throw(fn_name)
+    + "\n"
+    + "  }"
 }
 
 fn path_bindings_parts_render(parts) {
@@ -1970,7 +2023,105 @@ fn _render_header_cookie_lines(header_params, cookie_params) {
   return join(lines, "\n  ")
 }
 
-fn _render_request_lines(method, has_body, body_required, body_prepare) {
+fn _idempotency_key_param(header_params) {
+  for p in header_params {
+    if to_string(p.get("name") ?? "").lower() == "idempotency-key" {
+      return p.ident
+    }
+  }
+  return nil
+}
+
+fn _connector_http_function(ret) {
+  if ret.response_mode == "json_any" || ret.response_mode == "json_dict" {
+    return "connector_http_json"
+  }
+  return "connector_http_request"
+}
+
+fn _connector_retry_attempts(method, idempotency_key_param) {
+  let normalized = to_string(method ?? "").lower()
+  if ["get", "head", "put", "delete", "options"].contains(normalized) {
+    return 3
+  }
+  if (normalized == "post" || normalized == "patch") && idempotency_key_param != nil {
+    return 3
+  }
+  return 1
+}
+
+fn _render_connector_options(method, fn_name, module_name, has_body, idempotency_key_param) {
+  var parts = [
+    _harn_dict_entry("headers", "request_headers"),
+    _harn_dict_entry("provider", "\"" + _escape_string(module_name) + "\""),
+    _harn_dict_entry("operation", "\"" + _escape_string(fn_name) + "\""),
+    _harn_dict_entry(
+      "retry",
+      "{max_attempts: " + to_string(_connector_retry_attempts(method, idempotency_key_param)) + "}",
+    ),
+  ]
+  if has_body {
+    parts = parts + [_harn_dict_entry("body", "body_str")]
+  }
+  if idempotency_key_param != nil {
+    parts = parts + [_harn_dict_entry("idempotency_key", idempotency_key_param)]
+  }
+  return _render_binding_dict(parts)
+}
+
+fn _render_connector_call(method, ret, options_expr, indent) {
+  return _connector_http_function(ret)
+    + "(\n"
+    + indent
+    + "  \""
+    + to_string(method ?? "get").upper()
+    + "\",\n"
+    + indent
+    + "  url,\n"
+    + indent
+    + "  "
+    + _indent_after_first(options_expr, indent)
+    + ",\n"
+    + indent
+    + ")"
+}
+
+fn _render_request_lines(
+  method,
+  has_body,
+  body_required,
+  body_prepare,
+  transport,
+  ret,
+  fn_name,
+  module_name,
+  idempotency_key_param,
+) {
+  if transport == "connector_policy" {
+    if !has_body {
+      let options = _render_connector_options(method, fn_name, module_name, false, idempotency_key_param)
+      return "let resp = " + _render_connector_call(method, ret, options, "  ")
+    }
+    if body_required {
+      let options = _render_connector_options(method, fn_name, module_name, true, idempotency_key_param)
+      return body_prepare + "\n  let resp = " + _render_connector_call(method, ret, options, "  ")
+    }
+    let no_body_options = _render_connector_options(method, fn_name, module_name, false, idempotency_key_param)
+    let body_options = _render_connector_options(method, fn_name, module_name, true, idempotency_key_param)
+    return "var resp = nil\n"
+      + "  if body == nil {\n"
+      + "    resp = "
+      + _render_connector_call(method, ret, no_body_options, "    ")
+      + "\n"
+      + "  } else {\n"
+      + "    "
+      + _indent_after_first(body_prepare, "    ")
+      + "\n"
+      + "    resp = "
+      + _render_connector_call(method, ret, body_options, "    ")
+      + "\n"
+      + "  }"
+  }
   if !has_body {
     return "let resp = http_" + method + "(url, {headers: request_headers})"
   }
@@ -1992,12 +2143,24 @@ fn _render_request_lines(method, has_body, body_required, body_prepare) {
     + "  }"
 }
 
-fn _render_return_lines(fn_name, ret) {
+fn _render_return_lines(fn_name, ret, transport) {
   if ret.returns_nil {
     return "return nil"
   }
   if ret.response_mode == "opaque" {
     return "return {status: resp.status, headers: resp.headers, body: resp.body}"
+  }
+  if transport == "connector_policy" {
+    if ret.response_mode == "json_any" {
+      return "return resp.json"
+    }
+    return "let raw = resp.json\n"
+      + "  if type_of(raw) != \"dict\" {\n"
+      + "    throw \""
+      + fn_name
+      + ": expected dict response, got \" + type_of(raw)\n"
+      + "  }\n"
+      + "  return raw"
   }
   if ret.response_mode == "json_any" {
     return "return json_parse(resp.body)"

--- a/tests/connector_policy_transport_smoke.harn
+++ b/tests/connector_policy_transport_smoke.harn
@@ -1,0 +1,164 @@
+// connector_policy_transport_smoke — issue #69 coverage for the opt-in
+// generated transport that routes SDK calls through std/connectors/shared.
+import { codegen_module, parse } from "../src/lib"
+
+fn harn_cmd(harness: Harness, args: string) -> string {
+  let bin = harness.env.get("HARN_BIN")
+  if bin != nil && bin != "" {
+    return bin + " " + args
+  }
+  return "harn " + args
+}
+
+fn require_contains(harness: Harness, haystack: string, needle: string, label: string) {
+  if !contains(haystack, needle) {
+    harness.stdio.println("---BEGIN GENERATED SOURCE---")
+    harness.stdio.println(haystack)
+    harness.stdio.println("---END GENERATED SOURCE---")
+    require false, "${label}: expected source to contain \"${needle}\""
+  }
+}
+
+fn require_not_contains(harness: Harness, haystack: string, needle: string, label: string) {
+  if contains(haystack, needle) {
+    harness.stdio.println("---BEGIN GENERATED SOURCE---")
+    harness.stdio.println(haystack)
+    harness.stdio.println("---END GENERATED SOURCE---")
+    require false, "${label}: expected source NOT to contain \"${needle}\""
+  }
+}
+
+fn check_generates(harness: Harness, src: string) -> string {
+  let module_stem = harness.fs.temp_dir() + "/harn-openapi-connector-policy-" + uuid()
+  let module_path = module_stem + ".harn"
+  harness.fs.write_text(module_path, src)
+  let check_result = shell(harn_cmd(harness, "check " + module_path))
+  if !check_result.success {
+    harness.stdio.println("---harn check stderr---")
+    harness.stdio.println(check_result.stderr)
+    harness.stdio.println("---harn check stdout---")
+    harness.stdio.println(check_result.stdout)
+  }
+  require check_result.success, "generated connector-policy SDK must pass `harn check`"
+  let fmt_result = shell(harn_cmd(harness, "fmt --check " + module_path))
+  if !fmt_result.success {
+    harness.stdio.println("---harn fmt --check stderr---")
+    harness.stdio.println(fmt_result.stderr)
+    harness.stdio.println("---harn fmt --check stdout---")
+    harness.stdio.println(fmt_result.stdout)
+  }
+  require fmt_result.success, "generated connector-policy SDK must pass `harn fmt --check`"
+  return module_stem
+}
+
+fn run_generated(harness: Harness, module_stem: string) {
+  let runner_path = harness.fs.temp_dir() + "/harn-openapi-connector-policy-runtime-" + uuid() + ".harn"
+  harness.fs
+    .write_text(
+    runner_path,
+    "import {\n"
+      + "  create_item,\n"
+      + "  create_optional_item,\n"
+      + "  create_unsafe_item,\n"
+      + "  invalid_json,\n"
+      + "  list_items,\n"
+      + "  new_client,\n"
+      + "  rate_limit_metadata,\n"
+      + "} from \""
+      + module_stem
+      + "\"\n\n"
+      + "@test\n"
+      + "pipeline default() {\n"
+      + "  let client = new_client(\"https://api.example.com\")\n"
+      + "  let rates = rate_limit_metadata()\n"
+      + "  assert_eq(rates[0].operation_id, \"listItems\")\n"
+      + "  assert(rates[0].remaining_headers.contains(\"RateLimit-Remaining\"), \"standard rate-limit metadata should be emitted\")\n"
+      + "  http_mock_clear()\n"
+      + "  http_mock(\"GET\", \"https://api.example.com/items\", {responses: [{status: 503, body: \"busy\"}, {status: 200, body: \"{\\\"results\\\":[]}\"}]})\n"
+      + "  let page = list_items(client)\n"
+      + "  let list_calls = http_mock_calls({include_sensitive: true})\n"
+      + "  assert_eq(type_of(page.results), \"list\")\n"
+      + "  assert_eq(len(list_calls), 2)\n"
+      + "  http_mock_clear()\n"
+      + "  http_mock(\"POST\", \"https://api.example.com/items/create\", {responses: [{status: 503, body: \"busy\"}, {status: 201, body: \"{\\\"id\\\":\\\"created\\\"}\"}]})\n"
+      + "  let created = create_item(client, \"idem-1\", {name: \"thing\"})\n"
+      + "  let create_calls = http_mock_calls({include_sensitive: true})\n"
+      + "  assert_eq(created.id, \"created\")\n"
+      + "  assert_eq(len(create_calls), 2)\n"
+      + "  assert_eq(create_calls[0].headers[\"idempotency-key\"], \"idem-1\")\n"
+      + "  http_mock_clear()\n"
+      + "  http_mock(\"POST\", \"https://api.example.com/items/unsafe\", {responses: [{status: 503, body: \"busy\"}, {status: 201, body: \"{\\\"id\\\":\\\"unsafe\\\"}\"}]})\n"
+      + "  let unsafe_caught = try { create_unsafe_item(client, {name: \"unsafe\"}); nil } catch (e) { e }\n"
+      + "  let unsafe_calls = http_mock_calls({include_sensitive: true})\n"
+      + "  assert_eq(type_of(unsafe_caught), \"dict\")\n"
+      + "  assert_eq(unsafe_caught.category, \"overloaded\")\n"
+      + "  assert_eq(len(unsafe_calls), 1)\n"
+      + "  http_mock_clear()\n"
+      + "  http_mock(\"POST\", \"https://api.example.com/items/optional\", {responses: [{status: 204, body: \"\"}, {status: 204, body: \"\"}]})\n"
+      + "  let no_body = create_optional_item(client)\n"
+      + "  let with_body = create_optional_item(client, {name: \"optional\"})\n"
+      + "  let optional_calls = http_mock_calls({include_sensitive: true})\n"
+      + "  assert_eq(no_body, nil)\n"
+      + "  assert_eq(with_body, nil)\n"
+      + "  assert_eq(len(optional_calls), 2)\n"
+      + "  assert_eq(optional_calls[0].get(\"body\"), nil)\n"
+      + "  assert_eq(json_parse(optional_calls[1].body).name, \"optional\")\n"
+      + "  http_mock_clear()\n"
+      + "  http_mock(\"GET\", \"https://api.example.com/items/invalid-json\", {status: 200, body: \"not json\"})\n"
+      + "  let invalid_caught = try { invalid_json(client); nil } catch (e) { e }\n"
+      + "  assert_eq(type_of(invalid_caught), \"dict\")\n"
+      + "  assert_eq(invalid_caught.category, \"invalid_json\")\n"
+      + "  assert_eq(invalid_caught.status, 200)\n"
+      + "  assert_eq(invalid_caught.operation, \"invalid_json\")\n"
+      + "  harness.stdio.println(\"connector_policy runtime: ok\")\n"
+      + "}\n",
+  )
+  let result = shell(harn_cmd(harness, "run " + runner_path))
+  if !result.success {
+    harness.stdio.println("---connector-policy runtime stderr---")
+    harness.stdio.println(result.stderr)
+    harness.stdio.println("---connector-policy runtime stdout---")
+    harness.stdio.println(result.stdout)
+  }
+  require result.success, "generated connector-policy SDK runtime assertions must pass"
+}
+
+@test
+pipeline test_main() {
+  let raw = harness.fs.read_text(source_dir() + "/fixtures/connector_policy.openapi.json")
+  let doc = parse(raw)
+  let raw_src = codegen_module(doc, {module_name: "raw_policy_fixture", client_name: "Client"})
+  require_not_contains(
+    harness,
+    raw_src,
+    "std/connectors/shared",
+    "raw transport should not import connector helpers",
+  )
+  require_contains(harness, raw_src, "http_get(", "raw transport remains default")
+  let src = codegen_module(
+    doc,
+    {module_name: "connector_policy", client_name: "Client", transport: "connector_policy"},
+  )
+  require_contains(
+    harness,
+    src,
+    "import { connector_http_json, connector_http_request } from \"std/connectors/shared\"",
+    "connector helper import",
+  )
+  require_contains(harness, src, "connector_http_json(\n    \"GET\"", "GET connector transport")
+  require_contains(harness, src, "connector_http_json(\n    \"POST\"", "POST connector transport")
+  require_contains(
+    harness,
+    src,
+    "connector_http_request(\n      \"POST\"",
+    "opaque connector transport",
+  )
+  require_contains(harness, src, "idempotency_key: idempotency_key", "idempotency option")
+  require_contains(harness, src, "retry: {max_attempts: 3}", "bounded retry option")
+  require_contains(harness, src, "retry: {max_attempts: 1}", "unsafe write no-retry option")
+  require_not_contains(harness, src, "http_get(", "raw GET transport should not be emitted")
+  require_not_contains(harness, src, "http_post(", "raw POST transport should not be emitted")
+  let module_stem = check_generates(harness, src)
+  run_generated(harness, module_stem)
+  harness.stdio.println("connector_policy_transport_smoke: ok")
+}

--- a/tests/fixtures/connector_policy.openapi.json
+++ b/tests/fixtures/connector_policy.openapi.json
@@ -1,0 +1,174 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Connector Policy Synthetic API",
+    "version": "0.0.1"
+  },
+  "servers": [
+    {
+      "url": "https://api.example.com"
+    }
+  ],
+  "paths": {
+    "/items": {
+      "get": {
+        "operationId": "listItems",
+        "summary": "List items",
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "rate limited",
+            "headers": {
+              "Retry-After": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "RateLimit-Remaining": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/items/create": {
+      "post": {
+        "operationId": "createItem",
+        "summary": "Create an item",
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/items/unsafe": {
+      "post": {
+        "operationId": "createUnsafeItem",
+        "summary": "Create an item without idempotency",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/items/optional": {
+      "post": {
+        "operationId": "createOptionalItem",
+        "summary": "Create an item with an optional body",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "accepted"
+          }
+        }
+      }
+    },
+    "/items/invalid-json": {
+      "get": {
+        "operationId": "invalidJson",
+        "summary": "Return invalid JSON",
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds opt-in `transport: "connector_policy"` codegen that imports `connector_http_request` / `connector_http_json` from `std/connectors/shared`.
- Threads explicit OpenAPI `Idempotency-Key` header parameters into connector helper options and emits bounded retry settings for safe/idempotent calls while keeping unsafe writes at one attempt by default.
- Adds a synthetic connector-policy fixture and smoke test covering raw default preservation, helper transport generation, idempotency retries, unsafe no-retry behavior, optional body calls, helper invalid-JSON envelopes, generated `harn check`, and generated `harn fmt --check`.
- Documents the transport layering rule and keeps broad cloud SDK generation out of `harn-openapi` scope.

Closes #69.

## Verification

- `/Users/ksinder/projects/harn/target/debug/harn check src scripts`
- `/Users/ksinder/projects/harn/target/debug/harn lint src scripts`
- `/Users/ksinder/projects/harn/target/debug/harn fmt --check src scripts tests`
- `HARN_BIN=/Users/ksinder/projects/harn/target/debug/harn /Users/ksinder/projects/harn/target/debug/harn test tests --parallel --timing` (16/16 passed)
- `HARN_BIN=/Users/ksinder/projects/harn/target/debug/harn /Users/ksinder/projects/harn/target/debug/harn run scripts/regen_demo.harn`
- `HARN_BIN=/Users/ksinder/projects/harn/target/debug/harn /Users/ksinder/projects/harn/target/debug/harn run scripts/package_install_smoke.harn`
