### PR TITLE
Emit minimal connector helper imports

### DIFF
--- a/src/lib.harn
+++ b/src/lib.harn
@@ -995,8 +995,8 @@ let _MODULE_TEMPLATE = """
    * Source doc: {{ doc_title }} (OpenAPI {{ openapi_version }})
    * Module:     {{ module_name }}
    */
-  {{ if connector_transport }}
-  import { connector_http_json, connector_http_request } from "std/connectors/shared"
+  {{ if has_connector_imports }}
+  import { {{ connector_imports }} } from "std/connectors/shared"
   {{ end }}
 
   {{ for alias in response_aliases }}
@@ -1360,6 +1360,7 @@ pub fn codegen_module(doc: OpenApiDoc, options: dict) -> string {
   for name in alias_cache.order {
     alias_entries = alias_entries + [{source: alias_cache.by_name.get(name)}]
   }
+  let connector_imports = _connector_imports(op_return_types, transport)
   let bindings = {
     doc_title: (doc.get("info") ?? {}).get("title") ?? module_name,
     openapi_version: doc.openapi,
@@ -1369,7 +1370,8 @@ pub fn codegen_module(doc: OpenApiDoc, options: dict) -> string {
     new_client_decl: new_client_decl,
     new_client_return: _render_new_client_return(client_fields),
     client_fields: client_fields,
-    connector_transport: transport == "connector_policy",
+    has_connector_imports: connector_imports != "",
+    connector_imports: connector_imports,
     auth_helpers: auth_helpers,
     operations: ops,
     response_aliases: alias_entries,
@@ -2037,6 +2039,30 @@ fn _connector_http_function(ret) {
     return "connector_http_json"
   }
   return "connector_http_request"
+}
+
+fn _connector_imports(return_types, transport: string) -> string {
+  if transport != "connector_policy" {
+    return ""
+  }
+  var needs_json = false
+  var needs_request = false
+  for ret in return_types {
+    let helper = _connector_http_function(ret)
+    if helper == "connector_http_json" {
+      needs_json = true
+    } else if helper == "connector_http_request" {
+      needs_request = true
+    }
+  }
+  var imports = []
+  if needs_json {
+    imports = imports + ["connector_http_json"]
+  }
+  if needs_request {
+    imports = imports + ["connector_http_request"]
+  }
+  return join(imports, ", ")
 }
 
 fn _connector_retry_attempts(method, idempotency_key_param) {

--- a/tests/connector_policy_transport_smoke.harn
+++ b/tests/connector_policy_transport_smoke.harn
@@ -123,6 +123,24 @@ fn run_generated(harness: Harness, module_stem: string) {
   require result.success, "generated connector-policy SDK runtime assertions must pass"
 }
 
+fn build_json_only_doc() -> string {
+  return json_stringify(
+    {
+      openapi: "3.1.0",
+      info: {title: "JSON-only API", version: "0.0.1"},
+      servers: [{url: "https://api.example.com"}],
+      paths: {
+        "/items": {
+          get: {
+            operationId: "list-items",
+            responses: {"200": {description: "ok", content: {"application/json": {schema: {type: "object"}}}}},
+          },
+        },
+      },
+    },
+  )
+}
+
 @test
 pipeline test_main() {
   let raw = harness.fs.read_text(source_dir() + "/fixtures/connector_policy.openapi.json")
@@ -157,5 +175,22 @@ pipeline test_main() {
     "raw transport should not import connector helpers",
   )
   require_contains(harness, raw_src, "http_get(", "explicit raw transport emits raw GET")
+  let json_only_src = codegen_module(
+    parse(build_json_only_doc()),
+    {module_name: "json_only_policy", client_name: "Client"},
+  )
+  require_contains(
+    harness,
+    json_only_src,
+    "import { connector_http_json } from \"std/connectors/shared\"",
+    "JSON-only connector import",
+  )
+  require_not_contains(
+    harness,
+    json_only_src,
+    "connector_http_request",
+    "JSON-only generated SDK should not import unused opaque connector helper",
+  )
+  check_generates(harness, json_only_src)
   harness.stdio.println("connector_policy_transport_smoke: ok")
 }


### PR DESCRIPTION
## Summary
- derive shared connector imports from generated operation response modes
- avoid importing `connector_http_request` for JSON-only SDK modules
- add connector-policy regression coverage for JSON-only generation

## Validation
- `harn fmt --check src scripts tests`
- `harn check src scripts tests`
- `harn lint src scripts tests`
- `harn package check`
- `HARN_BIN=/Users/ksinder/projects/harn/target/debug/harn harn test tests --parallel --timing`