### PR TITLE
[codex] Bump harn-openapi prerelease

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ SDK source code from them. Acts as the reference example of a non-trivial
 external Harn library and powers downstream typed SDKs such as
 [notion-sdk-harn](https://github.com/burin-labs/notion-sdk-harn).
 
-> Status: `0.1.0` pre-release package shape. Until a release tag exists, use a
+> Status: `0.1.1-rc.1` pre-release package shape. Until a release tag exists, use a
 > path dependency or explicit `@HEAD` package smoke for unreleased work.
 
 ## Intent
@@ -60,11 +60,11 @@ For unreleased local or stacked work, use a path dependency:
 harn-openapi = { path = "../harn-openapi" }
 ```
 
-After the `v0.1.0` release tag exists, consumers can use the versioned package
+After the `v0.1.1-rc.1` release tag exists, consumers can use the versioned package
 ref:
 
 ```sh
-harn add github.com/burin-labs/harn-openapi@v0.1.0
+harn add github.com/burin-labs/harn-openapi@v0.1.1-rc.1
 ```
 
 The CI package smoke uses the same package-manager path against the current
@@ -72,7 +72,7 @@ checkout (`<repo>@HEAD`) so pull requests are checked before a release tag
 exists. To test a published ref locally after tagging:
 
 ```sh
-HARN_PACKAGE_REF=github.com/burin-labs/harn-openapi@v0.1.0 \
+HARN_PACKAGE_REF=github.com/burin-labs/harn-openapi@v0.1.1-rc.1 \
   harn run scripts/package_install_smoke.harn
 ```
 

--- a/docs/migration-v0.1.0.md
+++ b/docs/migration-v0.1.0.md
@@ -5,13 +5,17 @@ connector and SDK repos. Once the `v0.1.0` tag exists, it replaces
 sibling-checkout assumptions with a versioned Harn package dependency while
 keeping path overrides for local multi-repo development.
 
+The current prerelease pin is `v0.1.1-rc.1`; prefer it for new downstream work
+because it includes the latest package-manager metadata and connector codegen
+polish.
+
 ## Consumer dependency
 
 Use a versioned package ref in normal connector and SDK repos after the release
 tag is published:
 
 ```sh
-harn add github.com/burin-labs/harn-openapi@v0.1.0
+harn add github.com/burin-labs/harn-openapi@v0.1.1-rc.1
 ```
 
 Then import through the package export path:
@@ -59,7 +63,7 @@ Run the consumer repo's normal Harn gate with the pinned Harn CLI. In this
 repo, the equivalent package-manager smoke is:
 
 ```sh
-HARN_PACKAGE_REF=github.com/burin-labs/harn-openapi@v0.1.0 \
+HARN_PACKAGE_REF=github.com/burin-labs/harn-openapi@v0.1.1-rc.1 \
   harn run scripts/package_install_smoke.harn
 ```
 

--- a/harn.toml
+++ b/harn.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harn-openapi"
-version = "0.1.0"
+version = "0.1.1-rc.1"
 description = "Pure-Harn OpenAPI 3.1 parser and SDK codegen helpers."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/burin-labs/harn-openapi"

--- a/scripts/package_install_smoke.harn
+++ b/scripts/package_install_smoke.harn
@@ -4,7 +4,7 @@
  *
  * By default the smoke installs the current checkout with `@HEAD`, which keeps
  * PR CI useful before a release tag exists. Set HARN_PACKAGE_REF to test a
- * published ref such as `github.com/burin-labs/harn-openapi@v0.1.0`.
+ * published ref such as `github.com/burin-labs/harn-openapi@v0.1.1-rc.1`.
  */
 fn _repo_root() -> string {
   return source_dir() + "/.."


### PR DESCRIPTION
## Summary

- bump `harn-openapi` package metadata to `0.1.1-rc.1`
- update install and package-smoke docs to point at `v0.1.1-rc.1`
- publish the `v0.1.1-rc.1` GitHub prerelease for downstream pinning

## Validation

- `harn fmt --check src scripts tests`
- `harn check src scripts`
- `harn lint src scripts`
- `HARN_BIN="$(command -v harn)" harn test tests --parallel --timing`
- `harn run scripts/regen_demo.harn`
- `HARN_BIN="$(command -v harn)" harn run scripts/package_install_smoke.harn`
- `harn run scripts/check_fixture_staleness.harn`
- `harn publish --dry-run --json`
- `HARN_PACKAGE_REF=github.com/burin-labs/harn-openapi@v0.1.1-rc.1 HARN_BIN="$(command -v harn)" harn run scripts/package_install_smoke.harn`
