### PR TITLE
Security sweep 2026-05-23: parser/codegen hardening

### DIFF
--- a/src/lib.harn
+++ b/src/lib.harn
@@ -561,20 +561,50 @@ fn _synth_operation_id(method, path) {
   return method + "_" + trimmed
 }
 
+// Hard backstop for $ref resolution depth. Per-chain cycle detection in
+// `_resolve_ref_inner` catches A -> B -> A, but a malicious spec can spread a
+// long ref chain across allOf branches; this cap prevents pathological recursion
+// (or accidental fan-out) from exhausting the stack during codegen.
+let _MAX_REF_DEPTH = 32
+
 /** Resolve a `$ref` against `doc`, merge one level of `allOf`. */
 pub fn schema(doc: OpenApiDoc, ref_or_inline: RefOr<Schema>) -> Schema {
-  let resolved = _resolve_ref(doc, ref_or_inline)
+  return _schema_inner(doc, ref_or_inline, [])
+}
+
+fn _schema_inner(doc, ref_or_inline, seen_refs) {
+  let resolved = _resolve_ref_inner(doc, ref_or_inline, seen_refs)
   let all_of = resolved.get("allOf")
   if all_of == nil {
     return resolved
   }
+  if type_of(all_of) == "list" && len(all_of) > _MAX_ALL_OF {
+    throw "harn-openapi.schema: allOf branch count " + to_string(len(all_of))
+      + " exceeds limit "
+      + to_string(_MAX_ALL_OF)
+  }
+  let next_seen = _ref_chain_for(ref_or_inline, seen_refs)
   var merged = {}
   for part in all_of {
-    let piece = _resolve_ref(doc, part)
+    let piece = _resolve_ref_inner(doc, part, next_seen)
     merged = _merge_schema(merged, piece)
   }
   let own = _omit_key(resolved, "allOf")
   return _merge_schema(merged, own)
+}
+
+fn _ref_chain_for(node, seen_refs) {
+  if type_of(node) != "dict" {
+    return seen_refs
+  }
+  let ref = node.get("$ref")
+  if ref == nil || type_of(ref) != "string" {
+    return seen_refs
+  }
+  if seen_refs.contains(ref) {
+    return seen_refs
+  }
+  return seen_refs + [ref]
 }
 
 fn _resolve_ref(doc, node) {
@@ -593,7 +623,10 @@ fn _resolve_ref_inner(doc, node, seen_refs) {
     throw "harn-openapi.schema: expected string $ref, got " + type_of(ref)
   }
   if seen_refs.contains(ref) {
-    throw "harn-openapi.schema: circular ref " + ref
+    throw "harn-openapi.schema: circular $ref detected: " + ref
+  }
+  if len(seen_refs) >= _MAX_REF_DEPTH {
+    throw "harn-openapi.schema: $ref depth exceeded " + to_string(_MAX_REF_DEPTH) + " at " + ref
   }
   let target = _lookup_ref(doc, ref)
   let resolved_target = _resolve_ref_inner(doc, target, seen_refs + [ref])
@@ -628,6 +661,12 @@ fn _unescape_pointer(seg) {
   return replace(replace(seg, "~1", "/"), "~0", "~")
 }
 
+// DoS backstops for malicious specs: a deeply chained allOf or a schema
+// declaring thousands of properties can spike CPU/memory during codegen.
+let _MAX_ALL_OF = 64
+
+let _MAX_PROPERTIES = 1024
+
 fn _merge_schema(base, overlay) {
   if type_of(overlay) != "dict" {
     return base
@@ -638,13 +677,25 @@ fn _merge_schema(base, overlay) {
     let v = entry.value
     if k == "properties" {
       let existing = merged.get("properties") ?? {}
-      merged = {...merged, properties: existing + v}
+      let combined = existing + v
+      if type_of(combined) == "dict" && len(combined) > _MAX_PROPERTIES {
+        throw "harn-openapi.schema: properties count " + to_string(len(combined))
+          + " exceeds limit "
+          + to_string(_MAX_PROPERTIES)
+      }
+      merged = {...merged, properties: combined}
     } else if k == "required" {
       let existing = merged.get("required") ?? []
       merged = {...merged, required: _dedupe(existing + v)}
     } else if k == "allOf" {
       let existing = merged.get("allOf") ?? []
-      merged = {...merged, allOf: existing + v}
+      let combined = existing + v
+      if type_of(combined) == "list" && len(combined) > _MAX_ALL_OF {
+        throw "harn-openapi.schema: allOf chain length " + to_string(len(combined))
+          + " exceeds limit "
+          + to_string(_MAX_ALL_OF)
+      }
+      merged = {...merged, allOf: combined}
     } else {
       merged = {...merged, [k]: v}
     }
@@ -3138,7 +3189,16 @@ fn _is_plain_identifier(s) {
 }
 
 fn _escape_string(s) {
-  var out = replace(to_string(s), "\\", "\\\\")
+  // Defence-in-depth: even though emitted code is re-checked by `harn check`
+  // in tests, control characters smuggled in from a malicious OpenAPI spec
+  // could close a Harn string literal early or break our codegen output. We
+  // explicitly escape \n, \r, \t, and reject any remaining ASCII control
+  // characters (U+0000-U+001F) before emitting.
+  let coerced = to_string(s)
+  if regex_match("[\\x00-\\x08\\x0b\\x0c\\x0e-\\x1f]", coerced) != nil {
+    throw "harn-openapi: control character in string value (only \\n, \\r, \\t are escaped, others are rejected)"
+  }
+  var out = replace(coerced, "\\", "\\\\")
   out = replace(out, "\"", "\\\"")
   out = replace(out, "\n", "\\n")
   out = replace(out, "\r", "\\r")

--- a/tests/security_hardening_smoke.harn
+++ b/tests/security_hardening_smoke.harn
@@ -1,0 +1,126 @@
+// security_hardening_smoke — guards added in the 2026-05-23 security sweep:
+//   F4 cycle detection + max-depth backstop in $ref resolution
+//   F5 maxAllOf / maxProperties ceiling in _merge_schema + schema()
+//   F6 _escape_string rejects ASCII control characters
+import { codegen_module, parse, schema } from "../src/lib"
+
+fn _circular_ref_doc() -> string {
+  // A -> B -> A is a $ref cycle inside a single resolution chain: the
+  // recursive _resolve_ref_inner sees `A` re-enter its `seen_refs` set and
+  // throws. The allOf-level cycle is handled separately by the depth cap.
+  return """
+    {
+      "openapi": "3.1.0",
+      "info": { "title": "Cycle", "version": "1.0.0" },
+      "paths": {},
+      "components": {
+        "schemas": {
+          "A": { "$ref": "#/components/schemas/B" },
+          "B": { "$ref": "#/components/schemas/A" }
+        }
+      }
+    }
+    """
+}
+
+fn _long_all_of_doc(chain_len: int) -> string {
+  var parts = "["
+  var sep = ""
+  var i = 0
+  while i < chain_len {
+    parts = parts + sep + "{\"type\":\"object\"}"
+    sep = ","
+    i = i + 1
+  }
+  parts = parts + "]"
+  return "{"
+    + "\"openapi\":\"3.1.0\","
+    + "\"info\":{\"title\":\"Long\",\"version\":\"1.0.0\"},"
+    + "\"paths\":{},"
+    + "\"components\":{\"schemas\":{\"Long\":{\"allOf\":"
+    + parts
+    + "}}}"
+    + "}"
+}
+
+fn _ctrl_char_doc() -> string {
+  // Smuggle a NUL byte via JSON's   escape into an apiKey security
+  // scheme name. The parser accepts the escape (valid JSON); codegen funnels
+  // the scheme name through `_escape_string` (in `_render_auth_helper` for
+  // apiKey-header / apiKey-query / apiKey-cookie schemes), which must reject
+  // the control byte before it ends up in emitted source.
+  return "{"
+    + "\"openapi\":\"3.1.0\","
+    + "\"info\":{\"title\":\"Ctrl\",\"version\":\"1.0.0\"},"
+    + "\"paths\":{\"/x\":{\"get\":{"
+    + "\"operationId\":\"getx\","
+    + "\"responses\":{\"200\":{\"description\":\"ok\"}},"
+    + "\"security\":[{\"bad\\u0000name\":[]}]}}},"
+    + "\"components\":{\"securitySchemes\":{\"bad\\u0000name\":{\"type\":\"apiKey\",\"in\":\"header\",\"name\":\"X-API-Key\"}}},"
+    + "\"security\":[{\"bad\\u0000name\":[]}]"
+    + "}"
+}
+
+@test
+pipeline test_f4_circular_ref_detected() {
+  let doc = parse(_circular_ref_doc())
+  let caught = try {
+    let _ignored = schema(doc, {"$ref": "#/components/schemas/A"})
+    nil
+  } catch (e) {
+    e
+  }
+  assert(caught != nil, "expected circular $ref to throw")
+  let msg = to_string(caught)
+  assert(
+    contains(msg, "circular $ref") || contains(msg, "depth exceeded"),
+    "expected cycle or depth-cap message, got: " + msg,
+  )
+  harness.stdio.println("f4 circular ref: ok")
+}
+
+@test
+pipeline test_f5_all_of_branch_count_cap() {
+  let doc = parse(_long_all_of_doc(65))
+  let caught = try {
+    let _ignored = schema(doc, {"$ref": "#/components/schemas/Long"})
+    nil
+  } catch (e) {
+    e
+  }
+  assert(caught != nil, "expected oversize allOf branch count to throw")
+  assert(
+    contains(to_string(caught), "allOf branch count")
+      || contains(to_string(caught), "allOf chain length"),
+    "expected allOf cap message, got: " + to_string(caught),
+  )
+  harness.stdio.println("f5 allOf branch count cap: ok")
+}
+
+@test
+pipeline test_f5_all_of_at_cap_succeeds() {
+  // At exactly the cap (64), schema() must still succeed: caps should not
+  // regress legitimate-but-large specs.
+  let doc = parse(_long_all_of_doc(64))
+  let resolved = schema(doc, {"$ref": "#/components/schemas/Long"})
+  assert(type_of(resolved) == "dict", "schema() at allOf cap should succeed")
+  harness.stdio.println("f5 allOf at cap: ok")
+}
+
+@test
+pipeline test_f6_escape_string_rejects_nul() {
+  let doc = parse(_ctrl_char_doc())
+  assert(doc != nil, "ctrl-char doc should parse (JSON allows \\u0000 escapes)")
+  let caught = try {
+    let _src = codegen_module(doc, {module_name: "ctrl", client_name: "C"})
+    nil
+  } catch (e) {
+    e
+  }
+  assert(caught != nil, "codegen must reject NUL in identifiers")
+  assert(
+    contains(to_string(caught), "control character"),
+    "expected control-character rejection from _escape_string, got: " + to_string(caught),
+  )
+  harness.stdio.println("f6 escape_string: ok")
+}


### PR DESCRIPTION
## Summary

Pre-user-launch security sweep findings for the pure-Harn OpenAPI parser and codegen helpers:

- **F4 (MEDIUM, parser DoS)** — `$ref` resolution now enforces a hard depth cap (`_MAX_REF_DEPTH = 32`) on top of the existing per-chain cycle detection. `schema()` threads visited refs through its `allOf` merge step.
- **F5 (LOW-MED, billion-laughs)** — `schema()` and `_merge_schema` cap `allOf` branch count (`_MAX_ALL_OF = 64`) and `properties` count (`_MAX_PROPERTIES = 1024`). A malicious spec cannot exhaust CPU/memory during codegen.
- **F6 (LOW, defence-in-depth)** — `_escape_string` rejects ASCII control characters (U+0000–U+001F except the `\n`/`\r`/`\t` it already escapes) so a smuggled NUL via JSON's `\uXXXX` escape cannot close an emitted string literal early.

## Test plan

- [x] `harn check src scripts` — clean
- [x] `harn lint src scripts` — no issues
- [x] `harn fmt --check src scripts tests` — clean
- [x] `harn test tests --parallel` — 20/20 passing (4 new tests in `tests/security_hardening_smoke.harn`)
- [x] `harn run scripts/regen_demo.harn` — still regenerates the pinned Notion fixture (503 schemas, 46 ops) without tripping any cap

Cross-cutting fix wave context: shipped alongside parallel hardening PRs in `harn-sdk-python`, `harn-sdk-typescript`, and `notion-sdk-harn`. See `/tmp/harn-security-sweep/findings/03-sdks-parsers.md` for the full audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)