### PR TITLE
Sign automation commits via createCommitOnBranch

### DIFF
--- a/.github/workflows/bump-harn.yml
+++ b/.github/workflows/bump-harn.yml
@@ -171,16 +171,76 @@ jobs:
       - name: Commit and push bump branch
         if: steps.update.outputs.changed == 'true'
         env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           VERSION: ${{ steps.version.outputs.version }}
+          REPO: ${{ github.repository }}
+        shell: bash
         run: |
           set -euo pipefail
           BRANCH="automation/bump-harn-runtime"
-          git config user.name "harn-release-bot[bot]"
-          git config user.email "harn-release-bot[bot]@users.noreply.github.com"
-          git checkout -B "${BRANCH}"
-          git add .harn-version README.md scripts src tests
-          git commit -m "chore: bump Harn runtime to ${VERSION}"
-          git push --force-with-lease origin HEAD:${BRANCH}
+          # Commits made via createCommitOnBranch using the App's
+          # installation token are signed by GitHub, satisfying the
+          # org-level required_signatures rule on the default branch.
+          # A local `git commit` + `git push` would land unsigned and
+          # block auto-merge on the resulting PR.
+          BASE_SHA="$(git rev-parse HEAD)"
+
+          if gh api "repos/${REPO}/git/refs/heads/${BRANCH}" >/dev/null 2>&1; then
+            gh api -X PATCH "repos/${REPO}/git/refs/heads/${BRANCH}" \
+              -f sha="${BASE_SHA}" -F force=true >/dev/null
+          else
+            gh api -X POST "repos/${REPO}/git/refs" \
+              -f ref="refs/heads/${BRANCH}" -f sha="${BASE_SHA}" >/dev/null
+          fi
+
+          ADDITIONS_JSON='[]'
+          while IFS= read -r path; do
+            [ -n "${path}" ] || continue
+            [ -f "${path}" ] || continue
+            CONTENT_B64="$(base64 -w0 < "${path}")"
+            ADDITIONS_JSON="$(jq --arg p "${path}" --arg c "${CONTENT_B64}" \
+              '. + [{path:$p, contents:$c}]' <<<"${ADDITIONS_JSON}")"
+          done < <(git diff --name-only --diff-filter=ACMRTUXB HEAD)
+
+          DELETIONS_JSON='[]'
+          while IFS= read -r path; do
+            [ -n "${path}" ] || continue
+            DELETIONS_JSON="$(jq --arg p "${path}" '. + [{path:$p}]' <<<"${DELETIONS_JSON}")"
+          done < <(git diff --name-only --diff-filter=D HEAD)
+
+          if [ "${ADDITIONS_JSON}" = '[]' ] && [ "${DELETIONS_JSON}" = '[]' ]; then
+            echo "No file changes detected for bump commit; aborting." >&2
+            exit 1
+          fi
+
+          REQ_FILE="$(mktemp)"
+          jq -n \
+            --arg repo "${REPO}" \
+            --arg branch "${BRANCH}" \
+            --arg headline "chore: bump Harn runtime to ${VERSION}" \
+            --arg oid "${BASE_SHA}" \
+            --argjson additions "${ADDITIONS_JSON}" \
+            --argjson deletions "${DELETIONS_JSON}" \
+            '{
+              query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid url } } }",
+              variables: {
+                input: {
+                  branch: {repositoryNameWithOwner: $repo, branchName: $branch},
+                  message: {headline: $headline},
+                  fileChanges: {additions: $additions, deletions: $deletions},
+                  expectedHeadOid: $oid
+                }
+              }
+            }' > "${REQ_FILE}"
+
+          RESPONSE="$(gh api graphql --input "${REQ_FILE}")"
+          COMMIT_OID="$(jq -r '.data.createCommitOnBranch.commit.oid // empty' <<<"${RESPONSE}")"
+          if [ -z "${COMMIT_OID}" ]; then
+            echo "createCommitOnBranch failed:" >&2
+            echo "${RESPONSE}" >&2
+            exit 1
+          fi
+          echo "Created signed commit ${COMMIT_OID} on ${BRANCH}." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Create or refresh PR
         if: steps.update.outputs.changed == 'true'


### PR DESCRIPTION
## Summary
- Replace `git commit && git push` in the automation workflow with GitHub's GraphQL `createCommitOnBranch` mutation. Commits created with the App's installation token are signed by GitHub server-side, satisfying the org-level `required_signatures` rule on the default branch.
- Resets the automation branch to the current base SHA first, then submits the change as a single signed commit with `expectedHeadOid` pinned to that SHA.

## Why
`required_signatures` on `~DEFAULT_BRANCH` of every burin-labs repo was silently blocking auto-merge on automation PRs. The squash-merge commit GitHub creates is signed, but the source-branch commit is not, so `gh pr merge --auto --squash` never triggers and bumps had to be merged by hand (see `harn-bump-fleet#92`/`#95`).

## Test plan
- [ ] Manually dispatch the workflow; confirm the resulting commit shows the "Verified" badge and that auto-merge fires when checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)