### PR TITLE
fix: make codegen substring ranges explicit

### DIFF
--- a/src/lib.harn
+++ b/src/lib.harn
@@ -638,7 +638,7 @@ fn _lookup_ref(doc, ref) {
   if !starts_with(ref, "#/") {
     throw "harn-openapi.schema: only local JSON Pointer refs are supported, got " + ref
   }
-  let parts = split(substring(ref, 2), "/")
+  let parts = split(substring(ref, 2, len(ref)), "/")
   var node = doc
   for raw_seg in parts {
     let seg = _unescape_pointer(raw_seg)
@@ -1273,7 +1273,7 @@ let _MODULE_TEMPLATE = """
     if path == "" {
       return base_url
     }
-    let base_has_slash = substring(base_url, len(base_url) - 1) == "/"
+    let base_has_slash = substring(base_url, len(base_url) - 1, len(base_url)) == "/"
     let path_has_slash = starts_with(path, "/")
     if base_has_slash && path_has_slash {
       return substring(base_url, 0, len(base_url) - 1) + path
@@ -2914,7 +2914,7 @@ fn _pascal_case(raw) {
     if seg != "" {
       let first = substring(seg, 0, 1).upper()
       let rest = if len(seg) > 1 {
-        substring(seg, 1)
+        substring(seg, 1, len(seg))
       } else {
         ""
       }
@@ -3083,11 +3083,11 @@ fn _snake_case_base(raw, fallback) {
   while i < len(cleaned) {
     let ch = substring(cleaned, i, i + 1)
     if ch == "_" {
-      if out != "" && substring(out, len(out) - 1) != "_" {
+      if out != "" && substring(out, len(out) - 1, len(out)) != "_" {
         out = out + "_"
       }
     } else {
-      if _is_upper(ch) && out != "" && substring(out, len(out) - 1) != "_" {
+      if _is_upper(ch) && out != "" && substring(out, len(out) - 1, len(out)) != "_" {
         out = out + "_"
       }
       out = out + ch.lower()

--- a/tests/response_types_smoke.harn
+++ b/tests/response_types_smoke.harn
@@ -256,5 +256,12 @@ pipeline test_main() {
     ),
     "get_user must return UserObjectResponse",
   )
+  // --- Acceptance 11: operation ids with multi-character segments
+  // must not be truncated by substring semantics. ---
+  assert(
+    contains(notion_src, "pub fn retrieve_a_block(client: dict, block_id, notion_version = nil)"),
+    "retrieve_a_block operation name must not be shortened",
+  )
+  assert(!contains(notion_src, "pub fn r(client: dict"), "operation name must not collapse to r")
   harness.stdio.println("response_types_smoke: ok")
 }


### PR DESCRIPTION
## Summary\n- make harn-openapi substring calls explicit about end indexes so current Harn does not truncate generated identifiers\n- add Notion fixture regression coverage for public operation names such as retrieve_a_block\n\n## Validation\n- harn check src scripts\n- harn lint src scripts\n- harn fmt --check src scripts tests\n- harn package check\n- HARN_BIN="/Users/ksinder/.cargo/bin/harn" harn test tests --parallel --timing\n- harn run scripts/regen_demo.harn\n- HARN_BIN="/Users/ksinder/.cargo/bin/harn" harn run --no-sandbox scripts/package_install_smoke.harn\n- harn run scripts/check_fixture_staleness.harn