### PR TITLE
Normalize bump-harn.yml to fleet canonical

### DIFF
--- a/.github/workflows/bump-harn.yml
+++ b/.github/workflows/bump-harn.yml
@@ -1,14 +1,14 @@
-name: Bump Harn runtime
+name: Bump Harn Runtime
 
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Optional Harn tag to bump to, for example v0.7.33. Defaults to the latest published release."
+        description: "Optional Harn release tag. Defaults to the latest published release."
         required: false
         type: string
   schedule:
-    - cron: "39 9 * * *"
+    - cron: "37 9 * * *"
 
 permissions:
   contents: write
@@ -49,7 +49,7 @@ jobs:
             VERSION="$(gh api repos/burin-labs/harn/releases/latest --jq '.tag_name')"
           fi
           if [[ ! "${VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Expected tag like v0.7.33, got '${VERSION}'" >&2
+            echo "Expected Harn release tag vMAJOR.MINOR.PATCH, got '${VERSION}'" >&2
             exit 1
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
@@ -93,51 +93,15 @@ jobs:
         if: steps.published.outputs.ready != 'true'
         run: exit 0
 
-      - name: Update Harn pin surfaces
+      - name: Update .harn-version
         id: update
         if: steps.published.outputs.ready == 'true'
         env:
-          VERSION: ${{ steps.version.outputs.version }}
           VERSION_NO_V: ${{ steps.version.outputs.version_no_v }}
         run: |
           set -euo pipefail
-          python3 - <<'PY'
-          import os
-          import re
-          from pathlib import Path
-
-          version_no_v = os.environ["VERSION_NO_V"]
-          Path(".harn-version").write_text(f"{version_no_v}\n", encoding="utf-8")
-
-          def replace(path_str: str, pattern: str, replacement: str, count: int = 0) -> None:
-              path = Path(path_str)
-              text = path.read_text(encoding="utf-8")
-              updated, matches = re.subn(pattern, replacement, text, count=count, flags=re.MULTILINE)
-              if matches == 0:
-                  raise SystemExit(f"{path_str}: bump marker not found")
-              path.write_text(updated, encoding="utf-8")
-
-          replace(
-              "scripts/bump_harn_cli_version.harn",
-              r"(harn run scripts/bump_harn_cli_version\.harn -- )[0-9]+\.[0-9]+\.[0-9]+",
-              rf"\g<1>{version_no_v}",
-              count=1,
-          )
-          replace(
-              "README.md",
-              r"(harn run scripts/bump_harn_cli_version\.harn -- )[0-9]+\.[0-9]+\.[0-9]+",
-              rf"\g<1>{version_no_v}",
-              count=1,
-          )
-          replace(
-              "README.md",
-              r"`v[0-9]+\.[0-9]+\.[0-9]+` is normalized to `[0-9]+\.[0-9]+\.[0-9]+`",
-              f"`v{version_no_v}` is normalized to `{version_no_v}`",
-              count=1,
-          )
-          PY
-
-          if git diff --quiet -- .harn-version scripts/bump_harn_cli_version.harn README.md; then
+          printf '%s\n' "${VERSION_NO_V}" > .harn-version
+          if git diff --quiet -- .harn-version; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
@@ -160,7 +124,12 @@ jobs:
 
       - name: Format with target Harn
         if: steps.update.outputs.changed == 'true'
-        run: harn fmt src scripts tests
+        run: |
+          set -euo pipefail
+          mapfile -t harn_files < <(git ls-files '*.harn')
+          if [ ${#harn_files[@]} -gt 0 ]; then
+            harn fmt "${harn_files[@]}"
+          fi
 
       - name: Stop when repo is already current
         if: steps.published.outputs.ready == 'true' && steps.update.outputs.changed != 'true'
@@ -193,22 +162,34 @@ jobs:
               -f ref="refs/heads/${BRANCH}" -f sha="${BASE_SHA}" >/dev/null
           fi
 
-          ADDITIONS_JSON='[]'
+          # Build additions/deletions as JSONL files. File content goes through
+          # `jq --rawfile` (file -> fd), never through argv, because Linux caps any
+          # single argv element at MAX_ARG_STRLEN (128 KiB); a base64-encoded source
+          # file >96 KiB would otherwise trip E2BIG on execve. The final request uses
+          # `--slurpfile`, which reassembles each JSONL stream into a JSON array via
+          # fd, so the total payload also bypasses ARG_MAX.
+          ADDITIONS_FILE="$(mktemp)"
+          : > "${ADDITIONS_FILE}"
           while IFS= read -r path; do
             [ -n "${path}" ] || continue
             [ -f "${path}" ] || continue
-            CONTENT_B64="$(base64 -w0 < "${path}")"
-            ADDITIONS_JSON="$(jq --arg p "${path}" --arg c "${CONTENT_B64}" \
-              '. + [{path:$p, contents:$c}]' <<<"${ADDITIONS_JSON}")"
+            B64_FILE="$(mktemp)"
+            base64 -w0 < "${path}" > "${B64_FILE}"
+            # rawfile preserves base64's trailing newline; GitHub's decoder rejects
+            # whitespace, so scrub any embedded newlines in jq.
+            jq -nc --arg p "${path}" --rawfile c "${B64_FILE}" \
+              '{path:$p, contents:($c | gsub("\n";""))}' >> "${ADDITIONS_FILE}"
+            rm -f "${B64_FILE}"
           done < <(git diff --name-only --diff-filter=ACMRTUXB HEAD)
 
-          DELETIONS_JSON='[]'
+          DELETIONS_FILE="$(mktemp)"
+          : > "${DELETIONS_FILE}"
           while IFS= read -r path; do
             [ -n "${path}" ] || continue
-            DELETIONS_JSON="$(jq --arg p "${path}" '. + [{path:$p}]' <<<"${DELETIONS_JSON}")"
+            jq -nc --arg p "${path}" '{path:$p}' >> "${DELETIONS_FILE}"
           done < <(git diff --name-only --diff-filter=D HEAD)
 
-          if [ "${ADDITIONS_JSON}" = '[]' ] && [ "${DELETIONS_JSON}" = '[]' ]; then
+          if [ ! -s "${ADDITIONS_FILE}" ] && [ ! -s "${DELETIONS_FILE}" ]; then
             echo "No file changes detected for bump commit; aborting." >&2
             exit 1
           fi
@@ -219,8 +200,8 @@ jobs:
             --arg branch "${BRANCH}" \
             --arg headline "chore: bump Harn runtime to ${VERSION}" \
             --arg oid "${BASE_SHA}" \
-            --argjson additions "${ADDITIONS_JSON}" \
-            --argjson deletions "${DELETIONS_JSON}" \
+            --slurpfile additions "${ADDITIONS_FILE}" \
+            --slurpfile deletions "${DELETIONS_FILE}" \
             '{
               query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid url } } }",
               variables: {
@@ -257,8 +238,8 @@ jobs:
           cat > "${BODY_FILE}" <<EOF
           ## Summary
           - bump the pinned \`harn-cli\` version in \`.harn-version\` to \`${VERSION_NO_V}\`
-          - refresh checked-in bump-script usage examples to the same version
           - refresh formatter output with \`${VERSION}\`
+          - let the normal CI workflow re-run the Harn checks against the published release
 
           ## Verification
           - GitHub Actions will re-run the repo's Harn CI lanes


### PR DESCRIPTION
Aligns this repo's Harn auto-bump workflow with the fleet-standard version (generic wording + layout-agnostic fmt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)