### PR TITLE
ci: add Dependabot config for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+
+# Cooldown defers freshly-published versions so a compromised release has time
+# to be yanked or flagged before Dependabot proposes it.
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    cooldown:
+      default-days: 7
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds weekly github-actions Dependabot coverage (7-day cooldown, grouped) matching the burin-labs house style.