### PR TITLE
docs: make agent guidance portable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,10 +15,10 @@ truth for coding-agent instructions in this repo.
 
 ## Harn references
 
-- For repo-wide Harn conventions, defer to
-  [`/Users/ksinder/projects/harn/AGENTS.md`](/Users/ksinder/projects/harn/AGENTS.md).
-- For syntax, use
-  [`/Users/ksinder/projects/harn/docs/llm/harn-quickref.md`](/Users/ksinder/projects/harn/docs/llm/harn-quickref.md).
+- For repo-wide Harn conventions, use the
+  [Harn agent guide](https://github.com/burin-labs/harn/blob/main/AGENTS.md).
+- For syntax, use the
+  [Harn quick reference](https://github.com/burin-labs/harn/blob/main/docs/llm/harn-quickref.md).
 - Before editing Harn code, run `harn skill list --json` and fetch the
   narrowest matching skill with `harn skill get <name> --full`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,5 +3,9 @@
 Claude agents should follow [AGENTS.md](./AGENTS.md). That file is the
 current source of truth for repo rules, local checks, and fixture refreshes.
 
-For Claude-specific Harn syntax help, use the upstream pointer skill at
-`/Users/ksinder/projects/harn/.claude/skills/harn-scripting/SKILL.md`.
+For Harn syntax and orchestration guidance, use the installed CLI:
+
+```sh
+harn skill list --json
+harn skill get <name> --full
+```


### PR DESCRIPTION
Replaces machine-specific sibling-checkout links with canonical Harn references and the installed CLI skill workflow.\n\nValidation: git diff --check; harn skill list --json.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-openapi/pr/150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786425132&installation_id=145974243&pr_number=150&repository=burin-labs%2Fharn-openapi&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-openapi%2Fpull%2F150&signature=30fd5f1c8f229a75995c7b14cdcb44559afd63569fc1320476714800872e5484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->