### PR TITLE
release: prepare harn-openapi v0.1.1-rc.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ SDK source code from them. Acts as the reference example of a non-trivial
 external Harn library and powers downstream typed SDKs such as
 [notion-sdk-harn](https://github.com/burin-labs/notion-sdk-harn).
 
-> Status: `0.1.1-rc.1` pre-release package shape. Until a release tag exists, use a
-> path dependency or explicit `@HEAD` package smoke for unreleased work.
+> Status: `v0.1.1-rc.2` is the current prerelease and supports Harn 0.10. Use
+> its tagged package ref for released consumption; use a path dependency or
+> explicit `@HEAD` for unreleased work.
 
 ## Intent
 
@@ -60,11 +61,10 @@ For unreleased local or stacked work, use a path dependency:
 harn-openapi = { path = "../harn-openapi" }
 ```
 
-After the `v0.1.1-rc.1` release tag exists, consumers can use the versioned package
-ref:
+The published `v0.1.1-rc.2` prerelease can be installed by tag:
 
 ```sh
-harn add github.com/burin-labs/harn-openapi@v0.1.1-rc.1
+harn add github.com/burin-labs/harn-openapi@v0.1.1-rc.2
 ```
 
 The CI package smoke uses the same package-manager path against the current
@@ -72,7 +72,7 @@ checkout (`<repo>@HEAD`) so pull requests are checked before a release tag
 exists. To test a published ref locally after tagging:
 
 ```sh
-HARN_PACKAGE_REF=github.com/burin-labs/harn-openapi@v0.1.1-rc.1 \
+HARN_PACKAGE_REF=github.com/burin-labs/harn-openapi@v0.1.1-rc.2 \
   harn run scripts/package_install_smoke.harn
 ```
 

--- a/harn.toml
+++ b/harn.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harn-openapi"
-version = "0.1.1-rc.1"
+version = "0.1.1-rc.2"
 description = "Pure-Harn OpenAPI 3.1 parser and SDK codegen helpers."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/burin-labs/harn-openapi"


### PR DESCRIPTION
Publishes a Harn 0.10-compatible prerelease to replace the obsolete Harn 0.8-only rc.1 tag. Updates install examples to the new tag.\n\nValidation: harn check src scripts; harn lint src scripts; harn fmt --check src scripts tests; harn package check; harn test tests --parallel --timing; harn run scripts/regen_demo.harn; harn run --no-sandbox scripts/package_install_smoke.harn; harn run scripts/check_fixture_staleness.harn; git diff --check.\n\nAfter merge: publish v0.1.1-rc.2 and rerun the package smoke against that tag.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-openapi/pr/151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786425541&installation_id=145974243&pr_number=151&repository=burin-labs%2Fharn-openapi&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-openapi%2Fpull%2F151&signature=b885ccda7327b63c954df7429f3a54010dfb09112b6881e12c166ef286cf642e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->