### PR TITLE
Fix tests for Harn 0.10.34 (nil narrowing + deterministic staleness)

### DIFF
--- a/tests/connector_helpers_smoke.harn
+++ b/tests/connector_helpers_smoke.harn
@@ -125,10 +125,10 @@ pipeline test_main() {
   )
   const rates = rate_limit_metadata(doc)
   assert(len(rates) == 1, "synthetic fixture should expose one rate-limit metadata entry")
-  assert(rates[0].operation_id == "listItems", "rate-limit metadata should be tied to listItems")
-  assert(rates[0].retry_after_header == "Retry-After", "Retry-After should be modeled")
+  assert(rates[0]?.operation_id == "listItems", "rate-limit metadata should be tied to listItems")
+  assert(rates[0]?.retry_after_header == "Retry-After", "Retry-After should be modeled")
   assert(
-    rates[0].remaining_headers.contains("X-RateLimit-Remaining"),
+    rates[0]?.remaining_headers?.contains("X-RateLimit-Remaining"),
     "remaining header should be modeled",
   )
   const src = codegen_module(doc, {module_name: "connector_helpers", client_name: "Client"})

--- a/tests/fixture_workflow_smoke.harn
+++ b/tests/fixture_workflow_smoke.harn
@@ -130,14 +130,39 @@ pipeline test_main() {
     contains(diff.stdout, "Stable (schema changed)"),
     "diff output must include schema changes that keep the same field names",
   )
-  const stale_cmd = harn_cmd(harness, "run " + repo_root + "/scripts/check_fixture_staleness.harn")
-  const stale = shell(stale_cmd)
+  // Assert the "ok" freshness path against a controlled, freshly captured
+  // fixture so this smoke test never depends on the committed fixture's
+  // wall-clock age. The committed fixture's real staleness is enforced by the
+  // dedicated fixture-staleness CI job.
+  const fresh_path = scratch + "/fresh.json"
+  const fresh_meta = fresh_path + ".meta.toml"
+  const fresh_body = "{\"ok\":true}\n"
+  harness.fs.write_text(fresh_path, fresh_body)
+  harness.fs.write_text(
+    fresh_meta,
+    "upstream_url = \"https://example.com/openapi.json\"\n"
+      + "captured_at = \""
+      + date_format(harness.clock.timestamp(), "%Y-%m-%dT%H:%M:%S%.3fZ", "UTC")
+      + "\"\n"
+      + "sha256 = \""
+      + sha256(fresh_body)
+      + "\"\n"
+      + "byte_size = "
+      + to_string(len(fresh_body))
+      + "\n",
+  )
+  const stale = shell(
+    harn_cmd(
+      harness,
+      "run " + repo_root + "/scripts/check_fixture_staleness.harn -- " + fresh_meta,
+    ),
+  )
   if !stale.success {
     harness.stdio.println(stale.stderr)
     harness.stdio.println(stale.stdout)
   }
-  assert(stale.success, "check_fixture_staleness.harn must pass for committed metadata")
-  assert(contains(stale.stdout, "fixture staleness: ok"), "fixture should not be stale yet")
+  assert(stale.success, "check_fixture_staleness.harn must pass for fresh valid metadata")
+  assert(contains(stale.stdout, "fixture staleness: ok"), "fresh fixture must report ok")
   const fixture_path = scratch + "/integrity.json"
   const meta_path = fixture_path + ".meta.toml"
   harness.fs.write_text(fixture_path, "{\"ok\":true}\n")

--- a/tests/ref_siblings_smoke.harn
+++ b/tests/ref_siblings_smoke.harn
@@ -45,7 +45,7 @@ pipeline test_main() {
   assert(bare.get("$ref") == nil, "bare $ref should resolve to the target schema")
   assert(bare.title == "Base title", "bare $ref should preserve target title")
   assert(bare.description == "Base description", "bare $ref should preserve target description")
-  assert(bare.properties.get("id") != nil, "bare $ref should preserve target properties")
+  assert(bare.properties?.get("id") != nil, "bare $ref should preserve target properties")
   const described = schema(
     doc,
     {"$ref": "#/components/schemas/BaseObject", description: "Caller description"},
@@ -62,11 +62,17 @@ pipeline test_main() {
     "$ref sibling title on allOf branch should survive merge",
   )
   assert(
-    composed.properties.get("id") != nil,
+    composed.properties?.get("id") != nil,
     "allOf merge should keep referenced branch properties",
   )
-  assert(composed.properties.get("name") != nil, "allOf merge should keep inline branch properties")
-  assert(composed.required.contains("id"), "allOf merge should keep referenced branch requirements")
-  assert(composed.required.contains("name"), "allOf merge should keep inline branch requirements")
+  assert(
+    composed.properties?.get("name") != nil,
+    "allOf merge should keep inline branch properties",
+  )
+  assert(
+    composed.required?.contains("id"),
+    "allOf merge should keep referenced branch requirements",
+  )
+  assert(composed.required?.contains("name"), "allOf merge should keep inline branch requirements")
   harness.stdio.println("ref_siblings_smoke: ok")
 }

--- a/tests/regression_bugs_smoke.harn
+++ b/tests/regression_bugs_smoke.harn
@@ -272,21 +272,21 @@ pipeline test_main() {
   assert(len(op.parameters) == 2, "path-level and operation parameters should merge")
   const webhooks = webhook_operations(doc)
   assert(len(webhooks) == 1, "referenced webhook path item should flatten")
-  assert(webhooks[0].operation_id == "widget-created", "webhook operation id should survive")
+  assert(webhooks[0]?.operation_id == "widget-created", "webhook operation id should survive")
   const resolved = schema(doc, {"$ref": "#/components/schemas/WidgetResponse"})
-  assert(resolved.properties.get("id") != nil, "chained $ref should keep base properties")
-  assert(resolved.properties.get("name") != nil, "$ref sibling properties should be additive")
-  assert(resolved.required.contains("id"), "chained $ref should keep base required fields")
-  assert(resolved.required.contains("name"), "$ref sibling required fields should be additive")
+  assert(resolved.properties?.get("id") != nil, "chained $ref should keep base properties")
+  assert(resolved.properties?.get("name") != nil, "$ref sibling properties should be additive")
+  assert(resolved.required?.contains("id"), "chained $ref should keep base required fields")
+  assert(resolved.required?.contains("name"), "$ref sibling required fields should be additive")
   const pages = pagination_plans(doc)
   assert(
-    len(pages) == 1 && pages[0].kind == "cursor",
+    len(pages) == 1 && pages[0]?.kind == "cursor",
     "pagination should resolve response refs and +json",
   )
   const rates = rate_limit_metadata(doc)
   assert(len(rates) == 1, "rate-limit metadata should resolve response refs")
   assert(
-    rates[0].retry_after_header == "Retry-After",
+    rates[0]?.retry_after_header == "Retry-After",
     "Retry-After should be found through response ref",
   )
   const ref_src = codegen_module(

--- a/tests/types_smoke.harn
+++ b/tests/types_smoke.harn
@@ -8,9 +8,9 @@ pipeline test_main() {
   assert(is_openapi_doc(doc), "parse(raw) should satisfy the OpenApiDoc guard")
   const ops: list<Operation> = operations(doc)
   assert(len(ops) > 40, "expected >40 typed operations")
-  assert(ops[0].method != nil, "typed operation should expose method")
-  assert(ops[0].path != nil, "typed operation should expose path")
-  assert(ops[0].operation_id != nil, "typed operation should expose operation_id")
+  assert(ops[0]?.method != nil, "typed operation should expose method")
+  assert(ops[0]?.path != nil, "typed operation should expose path")
+  assert(ops[0]?.operation_id != nil, "typed operation should expose operation_id")
   const ref_with_sibling = {
     "$ref": "#/components/schemas/annotationResponse",
     description: "sibling description",
@@ -29,12 +29,12 @@ pipeline test_main() {
     harness.fs.read_text(source_dir() + "/fixtures/connector_helpers.openapi.json"),
   )
   const helpers: list<AuthHelper> = auth_helpers(synthetic)
-  assert(helpers[0].scheme_name != nil, "AuthHelper should expose scheme_name")
+  assert(helpers[0]?.scheme_name != nil, "AuthHelper should expose scheme_name")
   const pages: list<PaginationPlan> = pagination_plans(synthetic)
-  assert(pages[0].operation_id != nil, "PaginationPlan should expose operation_id")
+  assert(pages[0]?.operation_id != nil, "PaginationPlan should expose operation_id")
   const rates: list<RateLimitMetadata> = rate_limit_metadata(synthetic)
   assert(
-    rates[0].retry_after_header == "Retry-After",
+    rates[0]?.retry_after_header == "Retry-After",
     "RateLimitMetadata should expose retry headers",
   )
   harness.stdio.println("types_smoke: ok")

--- a/tests/walk_smoke.harn
+++ b/tests/walk_smoke.harn
@@ -21,8 +21,7 @@ pipeline test_main() {
   harness.stdio.println("query op: ${query_op.method} ${query_op.path}")
   const body_schema_raw = query_op.request_body.content["application/json"].schema
   const resolved = schema(doc, body_schema_raw)
-  const fields = resolved.properties.keys()
-  fields.sort()
+  const fields = (resolved.properties?.keys() ?? []).sort()
   harness.stdio.println("request body fields (${len(fields)}):")
   for f in fields {
     harness.stdio.println("  - ${f}")

--- a/tests/webhook_smoke.harn
+++ b/tests/webhook_smoke.harn
@@ -61,7 +61,7 @@ pipeline test_main() {
     "resolved commentCreated payload schema must expose properties/oneOf/allOf/anyOf/type",
   )
   if has_props {
-    const field_names = resolved.properties.keys()
+    const field_names = resolved.properties?.keys() ?? []
     harness.stdio.println("commentCreated payload fields: ${len(field_names)}")
   }
   harness.stdio.println("webhook_smoke: ok")


### PR DESCRIPTION
Unblocks the v0.10.34 bump (the stale bump PR #163 will be reopened fresh after this lands).

**Two independent breakages under the new runtime:**

- **Nil narrowing**: 0.10.34 makes `list[index]` and nilable `.get()` results return `T?`. The smoke tests' direct access (`ops[0].method`, `schema.properties.get(...)`, `schema.required.contains(...)`) now needs optional-chaining. `sort()` is pure, so the walk-smoke keys+sort folds into one assignment.
- **Fixture staleness time-bomb**: `fixture_workflow_smoke` asserted `"fixture staleness: ok"` against the committed Notion fixture, whose wall-clock age crossed the 90-day warning threshold — unrelated to the runtime. Now asserts the freshness path against a controlled, freshly-captured fixture; the committed fixture's real staleness stays enforced by the dedicated `fixture-staleness` CI job (which only hard-fails at 180 days).

`harn check`/`lint`/`fmt`, `package check`, 20/20 smoke tests, regen demo, and package install smoke all pass on 0.10.34.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-openapi/pr/164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787321913&installation_model_id=426921&pr_number=164&repository=burin-labs%2Fharn-openapi&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-openapi%2Fpull%2F164&signature=777e5d5f721e497b5937ea1d6a7b266dfaaa45ef9d363c82eafaa055d072fa39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->