### PR TITLE
Point CLAUDE.md at AGENTS.md with a symlink

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,1 @@
-# CLAUDE.md - harn-openapi
-
-Claude agents should follow [AGENTS.md](./AGENTS.md). That file is the
-current source of truth for repo rules, local checks, and fixture refreshes.
-
-For Harn syntax and orchestration guidance, use the installed CLI:
-
-```sh
-harn skill list --json
-harn skill get <name> --full
-```
+AGENTS.md


### PR DESCRIPTION
## What

`CLAUDE.md` becomes a symlink to `AGENTS.md`.

## Why

`CLAUDE.md` was a hand-written paragraph whose only job was to say "read AGENTS.md". Across the harn and burin repos there were six different wordings of that same sentence, each one a file that can go stale independently of the thing it points at. A symlink says it once and cannot drift.

This matches burin-code and the connector repos, which already do this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-openapi/pr/169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787538051&installation_model_id=426921&pr_number=169&repository=burin-labs%2Fharn-openapi&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-openapi%2Fpull%2F169&signature=f798fc57512d373a39e7da7618a1d06d0e6cdf3bb57be684c49cae714018f3c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->