### PR TITLE
Adopt the reusable bump workflow and gate it on ci.yml's checks

### DIFF
--- a/.github/workflows/bump-harn.yml
+++ b/.github/workflows/bump-harn.yml
@@ -1,10 +1,16 @@
+# Bump Harn Runtime — thin caller of the reusable workflow (harn#5299).
+#
+# Replaces the ~267L copied shell/YAML state machine with a trigger wrapper that
+# calls burin-labs/harn's published `workflow_call` workflow. All orchestration
+# (pin resolve, readiness gate, lockfile refresh, signed commit, PR + auto-merge)
+# lives in Harn (`std/bump/runtime`/`std/bump/live`), not here. The only
+# repo-specific parts are the schedule and the single validate-command.
 name: Bump Harn Runtime
-
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Optional Harn release tag. Defaults to the latest published release."
+        description: "Optional Harn tag (vX.Y.Z). Defaults to latest release."
         required: false
         type: string
   schedule:
@@ -14,254 +20,48 @@ permissions:
   contents: write
   pull-requests: write
 
-concurrency:
-  group: bump-harn-runtime
-  cancel-in-progress: false
-
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   bump:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Mint GitHub App installation token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-
-      - uses: actions/checkout@v7.0.0
-        with:
-          fetch-depth: 0
-          token: ${{ steps.app-token.outputs.token }}
-
-      - name: Resolve target Harn release
-        id: version
-        env:
-          GH_TOKEN: ${{ github.token }}
-          INPUT_VERSION: ${{ inputs.version }}
-        run: |
-          set -euo pipefail
-          VERSION="${INPUT_VERSION:-}"
-          if [ -z "${VERSION}" ]; then
-            VERSION="$(gh api repos/burin-labs/harn/releases/latest --jq '.tag_name')"
-          fi
-          if [[ ! "${VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Expected Harn release tag vMAJOR.MINOR.PATCH, got '${VERSION}'" >&2
-            exit 1
-          fi
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "version_no_v=${VERSION#v}" >> "$GITHUB_OUTPUT"
-
-      - name: Wait for Harn artifacts to exist
-        id: published
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-          VERSION_NO_V: ${{ steps.version.outputs.version_no_v }}
-        run: |
-          set -euo pipefail
-          CRATE_READY=false
-          BINARY_READY=false
-
-          if curl -fsSL \
-            -A "burin-labs/${{ github.event.repository.name }} bump-harn workflow" \
-            -H "Accept: application/json" \
-            "https://crates.io/api/v1/crates/harn-cli/${VERSION_NO_V}" >/dev/null; then
-            CRATE_READY=true
-          fi
-
-          if curl -fsSIL \
-            "https://github.com/burin-labs/harn/releases/download/${VERSION}/harn-x86_64-unknown-linux-gnu.tar.gz" >/dev/null; then
-            BINARY_READY=true
-          fi
-
-          if [ "${CRATE_READY}" = "true" ] && [ "${BINARY_READY}" = "true" ]; then
-            echo "ready=true" >> "$GITHUB_OUTPUT"
-            echo "harn-cli ${VERSION_NO_V} is published to crates.io and the Linux release binary exists." >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "ready=false" >> "$GITHUB_OUTPUT"
-            {
-              echo "Skipping bump for ${VERSION}: required Harn artifacts are not all published yet."
-              echo "crates.io harn-cli ${VERSION_NO_V}: ${CRATE_READY}"
-              echo "Linux release binary: ${BINARY_READY}"
-            } >> "$GITHUB_STEP_SUMMARY"
-          fi
-
-      - name: Stop when artifacts are not ready
-        if: steps.published.outputs.ready != 'true'
-        run: exit 0
-
-      - name: Update .harn-version
-        id: update
-        if: steps.published.outputs.ready == 'true'
-        env:
-          VERSION_NO_V: ${{ steps.version.outputs.version_no_v }}
-        run: |
-          set -euo pipefail
-          printf '%s\n' "${VERSION_NO_V}" > .harn-version
-          if git diff --quiet -- .harn-version; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Install target Harn
-        if: steps.update.outputs.changed == 'true'
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-          VERSION_NO_V: ${{ steps.version.outputs.version_no_v }}
-        run: |
-          set -euo pipefail
-          harn_root="${RUNNER_TEMP}/harn-${VERSION_NO_V}"
-          mkdir -p "${harn_root}/bin"
-          curl -fsSL \
-            -o "${RUNNER_TEMP}/harn.tar.gz" \
-            "https://github.com/burin-labs/harn/releases/download/${VERSION}/harn-x86_64-unknown-linux-gnu.tar.gz"
-          tar -xzf "${RUNNER_TEMP}/harn.tar.gz" -C "${harn_root}/bin"
-          echo "${harn_root}/bin" >> "${GITHUB_PATH}"
-
-      - name: Format with target Harn
-        if: steps.update.outputs.changed == 'true'
-        run: |
-          set -euo pipefail
-          mapfile -t harn_files < <(git ls-files '*.harn')
-          if [ ${#harn_files[@]} -gt 0 ]; then
-            harn fmt "${harn_files[@]}"
-          fi
-
-      - name: Stop when repo is already current
-        if: steps.published.outputs.ready == 'true' && steps.update.outputs.changed != 'true'
-        run: |
-          echo "Harn pin already matches ${{ steps.version.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
-          exit 0
-
-      - name: Commit and push bump branch
-        if: steps.update.outputs.changed == 'true'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          VERSION: ${{ steps.version.outputs.version }}
-          REPO: ${{ github.repository }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          BRANCH="automation/bump-harn-runtime"
-          # Commits made via createCommitOnBranch using the App's
-          # installation token are signed by GitHub, satisfying the
-          # org-level required_signatures rule on the default branch.
-          # A local `git commit` + `git push` would land unsigned and
-          # block auto-merge on the resulting PR.
-          BASE_SHA="$(git rev-parse HEAD)"
-
-          if gh api "repos/${REPO}/git/refs/heads/${BRANCH}" >/dev/null 2>&1; then
-            gh api -X PATCH "repos/${REPO}/git/refs/heads/${BRANCH}" \
-              -f sha="${BASE_SHA}" -F force=true >/dev/null
-          else
-            gh api -X POST "repos/${REPO}/git/refs" \
-              -f ref="refs/heads/${BRANCH}" -f sha="${BASE_SHA}" >/dev/null
-          fi
-
-          # Build additions/deletions as JSONL files. File content goes through
-          # `jq --rawfile` (file -> fd), never through argv, because Linux caps any
-          # single argv element at MAX_ARG_STRLEN (128 KiB); a base64-encoded source
-          # file >96 KiB would otherwise trip E2BIG on execve. The final request uses
-          # `--slurpfile`, which reassembles each JSONL stream into a JSON array via
-          # fd, so the total payload also bypasses ARG_MAX.
-          ADDITIONS_FILE="$(mktemp)"
-          : > "${ADDITIONS_FILE}"
-          while IFS= read -r path; do
-            [ -n "${path}" ] || continue
-            [ -f "${path}" ] || continue
-            B64_FILE="$(mktemp)"
-            base64 -w0 < "${path}" > "${B64_FILE}"
-            # rawfile preserves base64's trailing newline; GitHub's decoder rejects
-            # whitespace, so scrub any embedded newlines in jq.
-            jq -nc --arg p "${path}" --rawfile c "${B64_FILE}" \
-              '{path:$p, contents:($c | gsub("\n";""))}' >> "${ADDITIONS_FILE}"
-            rm -f "${B64_FILE}"
-          done < <(git diff --name-only --diff-filter=ACMRTUXB HEAD)
-
-          DELETIONS_FILE="$(mktemp)"
-          : > "${DELETIONS_FILE}"
-          while IFS= read -r path; do
-            [ -n "${path}" ] || continue
-            jq -nc --arg p "${path}" '{path:$p}' >> "${DELETIONS_FILE}"
-          done < <(git diff --name-only --diff-filter=D HEAD)
-
-          if [ ! -s "${ADDITIONS_FILE}" ] && [ ! -s "${DELETIONS_FILE}" ]; then
-            echo "No file changes detected for bump commit; aborting." >&2
-            exit 1
-          fi
-
-          REQ_FILE="$(mktemp)"
-          jq -n \
-            --arg repo "${REPO}" \
-            --arg branch "${BRANCH}" \
-            --arg headline "chore: bump Harn runtime to ${VERSION}" \
-            --arg oid "${BASE_SHA}" \
-            --slurpfile additions "${ADDITIONS_FILE}" \
-            --slurpfile deletions "${DELETIONS_FILE}" \
-            '{
-              query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid url } } }",
-              variables: {
-                input: {
-                  branch: {repositoryNameWithOwner: $repo, branchName: $branch},
-                  message: {headline: $headline},
-                  fileChanges: {additions: $additions, deletions: $deletions},
-                  expectedHeadOid: $oid
-                }
-              }
-            }' > "${REQ_FILE}"
-
-          RESPONSE="$(gh api graphql --input "${REQ_FILE}")"
-          COMMIT_OID="$(jq -r '.data.createCommitOnBranch.commit.oid // empty' <<<"${RESPONSE}")"
-          if [ -z "${COMMIT_OID}" ]; then
-            echo "createCommitOnBranch failed:" >&2
-            echo "${RESPONSE}" >&2
-            exit 1
-          fi
-          echo "Created signed commit ${COMMIT_OID} on ${BRANCH}." >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Create or refresh PR
-        if: steps.update.outputs.changed == 'true'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          REPO: ${{ github.repository }}
-          VERSION: ${{ steps.version.outputs.version }}
-          VERSION_NO_V: ${{ steps.version.outputs.version_no_v }}
-        run: |
-          set -euo pipefail
-          BRANCH="automation/bump-harn-runtime"
-          TITLE="Bump Harn runtime to ${VERSION}"
-          BODY_FILE="$(mktemp)"
-          cat > "${BODY_FILE}" <<EOF
-          ## Summary
-          - bump the pinned \`harn-cli\` version in \`.harn-version\` to \`${VERSION_NO_V}\`
-          - refresh formatter output with \`${VERSION}\`
-          - let the normal CI workflow re-run the Harn checks against the published release
-
-          ## Verification
-          - GitHub Actions will re-run the repo's Harn CI lanes
-          EOF
-
-          PR_NUMBER="$(gh pr list --repo "${REPO}" --head "${BRANCH}" --base main --json number --jq '.[0].number // ""')"
-          if [ -n "${PR_NUMBER}" ]; then
-            gh pr edit "${PR_NUMBER}" --repo "${REPO}" --title "${TITLE}" --body-file "${BODY_FILE}"
-          else
-            gh pr create \
-              --repo "${REPO}" \
-              --base main \
-              --head "${BRANCH}" \
-              --title "${TITLE}" \
-              --body-file "${BODY_FILE}"
-          fi
-
-          PR_NUMBER="$(gh pr list --repo "${REPO}" --head "${BRANCH}" --base main --json number --jq '.[0].number // ""')"
-          if [ -n "${PR_NUMBER}" ]; then
-            if gh pr merge "${PR_NUMBER}" --repo "${REPO}" --auto --squash; then
-              echo "Enabled auto-merge for #${PR_NUMBER}." >> "$GITHUB_STEP_SUMMARY"
-            else
-              echo "Created or refreshed #${PR_NUMBER}, but auto-merge is not enabled for this repository." >> "$GITHUB_STEP_SUMMARY"
-            fi
-          fi
+    # PIN: v0.10.34 release commit of burin-labs/harn.
+    uses: burin-labs/harn/.github/workflows/bump-harn.yml@e9e1ac66009672132267261a47cdcd19705e40f1
+    with:
+      version: ${{ inputs.version }}
+      # This repo's single declared validation entrypoint. Runs after the pin +
+      # lockfile refresh; non-zero exit blocks the commit. POSIX-sh only — the
+      # runtime executes this through the host default shell (std/command shell
+      # mode), which on a runner may resolve to /bin/sh (dash), not bash. No
+      # bashisms (mapfile/pipefail/(( ))): keep this portable regardless of
+      # runner shell.
+      #
+      # This mirrors the `harn` job in `.github/workflows/ci.yml`. The previous
+      # hand-rolled bump workflow only ran `harn fmt`, so it could green-light a
+      # runtime bump that broke codegen, the package manifest, or install; every
+      # one of those gates now runs before the commit.
+      #
+      # Deliberately NOT folded in: `scripts/check_fixture_staleness.harn` (the
+      # `fixture-staleness` CI job). Despite the name it is not a Harn-version
+      # gate — it compares `tests/fixtures/notion.openapi.json.meta.toml`'s
+      # `captured_at` against a 90-day warn / 180-day fail calendar budget for a
+      # pinned third-party spec. Folding it in would hard-fail the daily bump on
+      # a date unrelated to Harn (the pin is already past the warn threshold),
+      # and the only fix — `scripts/refresh_fixtures.harn` — refetches live
+      # upstream content, which must not land in an unattended signed commit. It
+      # stays in ci.yml, where it gates PRs and pushes as intended.
+      #
+      # Deviation from ci.yml, deliberate: ci.yml runs `harn fmt --check`
+      # because it verifies a PR; here `harn fmt` REWRITES, so a formatter
+      # change in the new runtime lands in the bump commit and the PR's own
+      # ci.yml `--check` then passes. Verifying here would instead wedge the
+      # daily bump permanently on any formatter change.
+      validate-command: |
+        set -eu
+        harn check src scripts
+        harn lint src scripts
+        harn fmt src scripts tests
+        harn package check
+        harn test tests --parallel --timing
+        harn run scripts/regen_demo.harn
+        harn run --no-sandbox scripts/package_install_smoke.harn
+    secrets:
+      app-client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
+      app-private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ CLI pinned by `.harn-version`.
 | `scripts/check_fixture_staleness.harn` | CI guard for fixture age. |
 | `scripts/package_install_smoke.harn` | Clean temp-project install/import smoke for package-manager consumption. |
 | `.harn-version` | Pinned Harn CLI version used by CI and local gates. |
-| `scripts/bump_harn_cli_version.harn` | Updates the pinned Harn CLI version and runs the local gate. |
+| `scripts/bump_harn_cli_version.harn` | Local/manual path: updates the pinned Harn CLI version and runs the full gate against that release. Routine bumps are automated by `.github/workflows/bump-harn.yml`. |
 | `.github/workflows/ci.yml` | Harn check/lint/fmt/package/test/demo/fixture workflow with an aggregate `CI status` job for branch rules and merge queue. |
 | `docs/migration-v0.1.0.md` | Migration note for connector repos moving from sibling path imports to package-managed imports. |
 | `AGENTS.md` | Repo-specific instructions for coding agents. |
@@ -419,8 +419,16 @@ between 90 and 180 days, and fails non-`main` branches once the fixture is over
 
 ### Harn CLI version bumps
 
-GitHub Actions reads the Harn version from `.harn-version`. When a new Harn
-release is published, update that pin and run the local gate with:
+GitHub Actions reads the Harn version from `.harn-version`, stored as bare
+semver (`0.10.39`, no leading `v`).
+
+Routine bumps are automated. `.github/workflows/bump-harn.yml` is a thin caller
+of Harn's reusable `workflow_call` workflow; it runs daily, rewrites the pin,
+refreshes the lockfile, runs this repo's validation command, and opens a signed
+auto-merging PR. Nothing needs to be done by hand.
+
+To bump by hand — trying a candidate release locally, or reproducing an
+automated failure without pushing — use:
 
 ```sh
 harn run scripts/bump_harn_cli_version.harn -- 0.9.22
@@ -429,8 +437,10 @@ harn run scripts/bump_harn_cli_version.harn -- 0.9.22
 The script accepts a leading `v` (`v0.9.22` is normalized to `0.9.22`),
 installs that `harn-cli` release into a temp directory, then runs check, lint,
 formatting, the smoke test suite, `scripts/regen_demo.harn`, and
-`scripts/package_install_smoke.harn`. Use `--no-verify` only when you
-intentionally want to edit the version pin without running the gate.
+`scripts/package_install_smoke.harn`. Unlike the workflow it pins a specific
+version you name and verifies against a from-crates.io install, so it stays the
+local-development path. Use `--no-verify` only when you intentionally want to
+edit the version pin without running the gate.
 
 ## License
 

--- a/scripts/bump_harn_cli_version.harn
+++ b/scripts/bump_harn_cli_version.harn
@@ -1,5 +1,16 @@
 // Update the pinned harn-cli version used by local and CI gates.
 //
+// LOCAL/MANUAL PATH ONLY. Routine bumps are automated by
+// `.github/workflows/bump-harn.yml`, which calls Harn's reusable bump workflow
+// and writes `.harn-version` itself. This script is the hand-driven
+// counterpart, kept because it does something the automation cannot: pin an
+// arbitrary version you name and verify it against a real `cargo install
+// harn-cli` from crates.io on your machine, without pushing a branch. Use it to
+// try a candidate release or to reproduce an automated bump failure locally.
+//
+// Both writers normalize to bare semver (a leading "v" is stripped), so they
+// cannot disagree about the file format.
+//
 // Usage:
 //   harn run scripts/bump_harn_cli_version.harn -- 0.9.22
 //


### PR DESCRIPTION
## Summary

Deletes the 267-line hand-rolled `bump-harn.yml` state machine — pin rewrite, base64'd git diff, hand-assembled `createCommitOnBranch` GraphQL payload in shell+jq, PR open/auto-merge — and replaces it with a thin caller of Harn's published reusable workflow. Nineteen other fleet repos already made this move.

**267 → 67 lines**, of which the only repo-specific content is the schedule and one `validate-command`.

## The validation gap this closes

The old bump workflow validated a runtime bump with `harn fmt` **and nothing else**. It could green-light a Harn release that broke codegen, the package manifest, or package install. `ci.yml` runs far more.

`validate-command` now mirrors the `harn` job in `ci.yml`:

```sh
set -eu
harn check src scripts
harn lint src scripts
harn fmt src scripts tests
harn package check
harn test tests --parallel --timing
harn run scripts/regen_demo.harn
harn run --no-sandbox scripts/package_install_smoke.harn
```

Adoption is therefore a strict improvement in gate strength, not just a line-count reduction.

## Deliberately NOT folded in: fixture staleness

I was asked to fold in `scripts/check_fixture_staleness.harn` as a Harn-bump risk surface. Having read it, it is not one, and folding it in would be actively harmful.

It is a **calendar** check on a pinned third-party spec — it compares `tests/fixtures/notion.openapi.json.meta.toml`'s `captured_at` against a 90-day warn / 180-day fail budget. Nothing about it varies with the Harn version.

- The pin was captured `2026-04-20` and is **already 96 days old**, past the warn threshold.
- At 180 days (~2026-10-17) it starts hard-failing — which would wedge the daily Harn bump for a reason having nothing to do with Harn.
- Its only remedy, `scripts/refresh_fixtures.harn`, **refetches live content from `developers.notion.com`**. Pulling live third-party bytes into an unattended signed commit is not something an automated bump should do.

It stays in `ci.yml`'s separate `fixture-staleness` job, where it gates PRs and pushes as intended. The reasoning is recorded in a comment on the workflow so this is not silently re-litigated.

The **regen demo** is genuinely Harn-version-sensitive and *is* folded in.

## `scripts/bump_harn_cli_version.harn`: kept, not deleted

After adoption it is a second writer of `.harn-version` (`const _VERSION_REL_PATH = ".harn-version"`). Kept, because it does something the automation cannot: pin an arbitrary version you name and verify it against a real `cargo install harn-cli` from crates.io **on your machine, without pushing a branch** — for trying a candidate release or reproducing an automated bump failure locally. It is also covered by `tests/bump_harn_cli_version_smoke.harn`.

The redundancy is safe: both writers normalize to **bare semver** (the script strips a leading `v` in `_normalize_version`; the workflow uses `strip_v`), so they cannot disagree about the file format. Its header comment and the README now say plainly that it is the manual/local path and the workflow is the automation path.

## Doc drift fixed

- README "Harn CLI version bumps" rewritten: automation is the primary path, the script is the manual one, `.harn-version` documented as bare semver.
- README script table row for `bump_harn_cli_version.harn` relabelled.

## Verification

- Extracted the `validate-command` out of the YAML with `ruby -ryaml` and ran it **verbatim under `/bin/dash`** (not bash): **exit 0**, through the package-install smoke.
- `actionlint` clean; YAML parses.
- `grep -c '^  workflow_dispatch:$'` → `1` (load-bearing for harn-bump-fleet's discovery test).
- `.harn-version` is **bare semver `0.10.39`**, no leading `v` — matches what the reusable workflow writes.
- Working tree clean after the run.

One note: the smoke suite fails locally if `HARN_EGRESS_BLOCK_PRIVATE` is exported in the shell (`egress_policy: policy already configured from environment`). That is a local-environment artifact, not a repo issue — the runs above were done with it unset, and CI does not set it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-openapi/pr/171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787592543&installation_model_id=426921&pr_number=171&repository=burin-labs%2Fharn-openapi&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-openapi%2Fpull%2F171&signature=dbd14843712a58e8142755365e0da2e9c4dbff1e65e9d74cc4d488a8c87ddef8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->